### PR TITLE
add aws copilot

### DIFF
--- a/aws-copilot.hcl
+++ b/aws-copilot.hcl
@@ -32,15 +32,6 @@ linux {
     }
 }
 
-windows {
-    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-windows.exe"
-    on unpack {
-        rename { from = "${root}/copilot-windows.exe" to = "${root}/copilot.exe" }
-    }
-}
-
-
-
 version "1.8.2" {
     auto-version {
         github-release = "aws/copilot-cli"

--- a/aws-copilot.hcl
+++ b/aws-copilot.hcl
@@ -10,26 +10,10 @@ darwin {
 }
 
 linux {
-    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-linux"
-    on unpack {
-        rename { from = "${root}/copilot-linux" to = "${root}/copilot" }
-    }
-}
-
-linux {
-    arch = "amd64"
-    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-linux-amd64-v${version}"
-    on unpack {
-        rename { from = "${root}/copilot-linux-amd64-v${version}" to = "${root}/copilot" }
-    }
-}
-
-linux {
-    arch = "arm64"
-    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-linux-arm64"
-    on unpack {
-        rename { from = "${root}/copilot-linux-arm64" to = "${root}/copilot" }
-    }
+  source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-${os}-${arch}"
+  on unpack {
+    rename { from = "${root}/copilot-${os}-${arch}" to = "${root}/copilot" }
+  }
 }
 
 version "1.8.2" {

--- a/aws-copilot.hcl
+++ b/aws-copilot.hcl
@@ -12,7 +12,7 @@ darwin {
 linux {
   source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-${os}-${arch}-v${version}"
   on unpack {
-    rename { from = "${root}/copilot-${os}-${arch}" to = "${root}/copilot" }
+    rename { from = "${root}/copilot-${os}-${arch}-v${version}" to = "${root}/copilot" }
   }
 }
 

--- a/aws-copilot.hcl
+++ b/aws-copilot.hcl
@@ -1,0 +1,48 @@
+description = "AWS Copilot is an open source command line interface that makes it easy for developers to build, release, and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate."
+test = "copilot --help"
+binaries = ["copilot"]
+
+darwin {
+    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-darwin"
+    on unpack {
+        rename { from = "${root}/copilot-darwin" to = "${root}/copilot" }
+    }
+}
+
+linux {
+    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-linux"
+    on unpack {
+        rename { from = "${root}/copilot-linux" to = "${root}/copilot" }
+    }
+}
+
+linux {
+    arch = "amd64"
+    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-linux-amd64-v${version}"
+    on unpack {
+        rename { from = "${root}/copilot-linux-amd64-v${version}" to = "${root}/copilot" }
+    }
+}
+
+linux {
+    arch = "arm64"
+    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-linux-arm64"
+    on unpack {
+        rename { from = "${root}/copilot-linux-arm64" to = "${root}/copilot" }
+    }
+}
+
+windows {
+    source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-windows.exe"
+    on unpack {
+        rename { from = "${root}/copilot-windows.exe" to = "${root}/copilot.exe" }
+    }
+}
+
+
+
+version "1.8.2" {
+    auto-version {
+        github-release = "aws/copilot-cli"
+    }
+}

--- a/aws-copilot.hcl
+++ b/aws-copilot.hcl
@@ -10,7 +10,7 @@ darwin {
 }
 
 linux {
-  source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-${os}-${arch}"
+  source = "https://github.com/aws/copilot-cli/releases/download/v${version}/copilot-${os}-${arch}-v${version}"
   on unpack {
     rename { from = "${root}/copilot-${os}-${arch}" to = "${root}/copilot" }
   }


### PR DESCRIPTION
> AWS Copilot is an open source command line interface that makes it easy for developers to build, release, and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate.

https://aws.github.io/copilot-cli/
https://github.com/aws/copilot-cli/releases

It's my first time contributing a package so would appreciate any feedback and tips!