### PR TITLE
fix: make jx and kind multi-arch

### DIFF
--- a/jx.hcl
+++ b/jx.hcl
@@ -3,11 +3,11 @@ test = "jx version"
 binaries = ["jx"]
 
 linux {
-  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-linux-amd64.tar.gz"
+  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-linux-${arch}.tar.gz"
 }
 
 darwin {
-  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-darwin-amd64.tar.gz"
+  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-darwin-${arch}.tar.gz"
 }
 
 version "3.2.137" "3.2.140" "3.2.158" "3.2.159" "3.2.160" "3.2.162" "3.2.165" {

--- a/kind.hcl
+++ b/kind.hcl
@@ -3,16 +3,16 @@ test = "kind version"
 binaries = ["kind"]
 
 linux {
-  source = "https://github.com/kubernetes-sigs/kind/releases/download/v${version}/kind-linux-amd64"
+  source = "https://github.com/kubernetes-sigs/kind/releases/download/v${version}/kind-linux-${arch}"
   on unpack {
-    rename { from = "${root}/kind-linux-amd64" to = "${root}/kind" }
+    rename { from = "${root}/kind-linux-${arch}" to = "${root}/kind" }
   }
 }
 
 darwin {
-  source = "https://github.com/kubernetes-sigs/kind/releases/download/v${version}/kind-darwin-amd64"
+  source = "https://github.com/kubernetes-sigs/kind/releases/download/v${version}/kind-darwin-${arch}"
   on unpack {
-    rename { from = "${root}/kind-darwin-amd64" to = "${root}/kind" }
+    rename { from = "${root}/kind-darwin-${arch}" to = "${root}/kind" }
   }
 }
 


### PR DESCRIPTION
I'd missed the multi-arch support in packages; so lets add the ${arch} so that these packages can be used on arm as well