### PR TITLE
add current node version with auto-version

### DIFF
--- a/node.hcl
+++ b/node.hcl
@@ -12,14 +12,23 @@ version "12.18.3" {}
 version "14.16.0" "14.17.0" {}
 version "15.10.0" {}
 
-version "16.1.0" "16.2.0" "16.3.0" {
+version "16.1.0" "16.2.0" "16.3.0" "16.4.0" {
   darwin {
     arch = "arm64"
     source = "https://nodejs.org/dist/v${version}/node-v${version}-${os}-arm64.tar.gz"
+  }
+
+  auto-version {
+    github-release = "nodejs/node"
   }
 }
 
 channel lts {
   version = "14.*"
+  update = "168h" // Weekly update.
+}
+
+channel current {
+  version = "16.*"
   update = "168h" // Weekly update.
 }

--- a/node.hcl
+++ b/node.hcl
@@ -9,17 +9,18 @@ env = {
 }
 
 version "12.18.3" {}
-version "14.16.0" "14.17.0" {}
+version "14.16.0" "14.17.0" {
+  // auto-version grabs "latest" which is currently v14
+  auto-version {
+    github-release = "nodejs/node"
+  }
+}
 version "15.10.0" {}
 
 version "16.1.0" "16.2.0" "16.3.0" "16.4.0" {
   darwin {
     arch = "arm64"
     source = "https://nodejs.org/dist/v${version}/node-v${version}-${os}-arm64.tar.gz"
-  }
-
-  auto-version {
-    github-release = "nodejs/node"
   }
 }
 
@@ -30,5 +31,4 @@ channel lts {
 
 channel current {
   version = "16.*"
-  update = "168h" // Weekly update.
 }


### PR DESCRIPTION
v16.4 fixed a segmentation fault I came up across. also trying to enable auto-version with a new "current" channel which matches [Node.js' verbiage](https://nodejs.org/en/).