### PR TITLE
docs: Add Slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img align="right" width="100" height="100" src="hermit.svg" alt="Hermit">
 </a>
 
-# Hermit package manifests ![(CI status)](https://github.com/cashapp/hermit-packages/workflows/CI/badge.svg)
+# Hermit package manifests ![(CI status)](https://github.com/cashapp/hermit-packages/workflows/CI/badge.svg)  [![Slack chat](https://img.shields.io/badge/slack-gophers-795679?logo=slack)](https://gophers.slack.com/messages/cashapp)
 
 This repository contains package manifests for [Hermit](https://cashapp.github.io/hermit/).
 


### PR DESCRIPTION
Add Slack channel link to #cashapp at Gophers Slack to README.