### PR TITLE
Add package manifest for gojq

### DIFF
--- a/gojq.hcl
+++ b/gojq.hcl
@@ -1,0 +1,19 @@
+description = "gojq is a pure Go implemention of jq. jq is like sed for JSON data - you can use it to slice and filter and map and transform structured data with the same ease that sed, awk, grep and friends let you play with text."
+binaries = ["gojq"]
+test = "gojq --version"
+
+linux {
+  source = "https://github.com/itchyny/gojq/releases/download/v${version}/gojq_v${version}_linux_${arch}.tar.gz"
+  strip = 1
+}
+
+darwin {
+  source = "https://github.com/itchyny/gojq/releases/download/v${version}/gojq_v${version}_darwin_${arch}.zip"
+  strip = 1
+}
+
+version "0.12.5" {
+  auto-version {
+    github-release = "itchyny/gojq"
+  }
+}


### PR DESCRIPTION
Add a package manifest for gojq (https://github.com/itchyny/gojq) - a
pure Go implementation of jq that also supports YAML for input and
output. It has a few other differences as documented in its README. It
can also be used as a library in your Go programs.