### PR TITLE
Add protoc-gen-go-grpc

### DIFF
--- a/protoc-gen-go-grpc.hcl
+++ b/protoc-gen-go-grpc.hcl
@@ -1,0 +1,8 @@
+description = "protoc-gen-go-grpc is the Go implementation of gRPC: A high performance, open source, general RPC framework that puts mobile and HTTP/2 first."
+binaries = ["protoc-gen-go-grpc"]
+test = "protoc-gen-go-grpc --version"
+source = "https://github.com/grpc/grpc-go/releases/download/cmd/protoc-gen-go-grpc/v${version}/protoc-gen-go-grpc.v${version}.${os}.${arch}.tar.gz"
+strip = 1
+
+version "1.0.1" {}
+version "1.1.0" {}


### PR DESCRIPTION
Add protoc-gen-go-grpc, another golang protoc plugin.

link: https://grpc.io/docs/languages/go/quickstart/
link: https://github.com/grpc/grpc-go/releases/tag/cmd/protoc-gen-go-grpc/v1.1.0