### PR TITLE
add protoc-gen-grpc-web

### DIFF
--- a/protoc-gen-grpc-web.hcl
+++ b/protoc-gen-grpc-web.hcl
@@ -1,0 +1,17 @@
+description = "protoc-gen-grpc-web is a JavaScript implementation of gRPC for browser clients"
+requires = ["protoc"]
+binaries = ["protoc-gen-grpc-web"]
+source = "https://github.com/grpc/grpc-web/releases/download/${version}/protoc-gen-grpc-web-${version}-${os}-x86_64"
+
+on unpack {
+    rename {
+        from = "${root}/protoc-gen-grpc-web-${version}-${os}-x86_64"
+        to = "${root}/protoc-gen-grpc-web"
+    }
+}
+
+version "1.2.1" {
+    auto-version {
+        github-release = "grpc/grpc-web"
+    }
+}


### PR DESCRIPTION
Add protoc-gen-grpc-web for grpc-web

https://github.com/grpc/grpc-web#grpc-web
https://grpc.io/docs/platforms/web/quickstart/