### PR TITLE
ci: Anchor "hermit search" pattern to exclude submatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
           ~/bin/hermit validate "file://$PWD"
           ~/bin/hermit init --sources="file://$PWD" ./testenv
           . ./testenv/bin/activate-hermit
-          for pkg in $(git diff --name-only ${{ github.event.pull_request.base.sha }} | fgrep .hcl | cut -d. -f1 | xargs -n1 hermit search -s | grep -v '@'); do echo $pkg; hermit test -t $pkg; hermit clean -tp; done
+          for pkg in $(git diff --name-only ${{ github.event.pull_request.base.sha }} | fgrep .hcl | cut -d. -f1 | xargs -I{} -n1 hermit search -s '^{}$' | grep -v '@'); do echo $pkg; hermit test -t $pkg; hermit clean -tp; done


### PR DESCRIPTION
The CI check for testing only changed packages manages to pick up
packages in unchanged files, as the `hermit search` command used does
not anchor the regex. Anchor it so we only find the versions of packages
in changed files.