### PR TITLE
Add helm 3.6 patches and setup auto versioning

### DIFF
--- a/helm.hcl
+++ b/helm.hcl
@@ -12,4 +12,8 @@ version "3.4.0" "3.5.3" {
   }
 }
 
-version "3.6.0" {}
+version "3.6.0" "3.6.1" "3.6.2" "3.6.3" {
+  auto-version {
+    github-release = "helm/helm"
+  }
+}


### PR DESCRIPTION
Adds the 3.6.1, 3.6.2, and 3.6.3 helm releases manually and sets up auto
versioning such that new releases will be automatically added.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

> Note: thanks for y'all's work on `hermit`! I wasn't sure the exact logic behind how auto-versioning is pulling new versions (specifically if it only takes into account versions after the latest present version in the config file). If there are any updates you would like me to make here I would be more than happy to do so. These patches include a security vulnerability fix that was not present in 3.6.0.