### PR TITLE
Add package for flux cli

### DIFF
--- a/flux.hcl
+++ b/flux.hcl
@@ -1,0 +1,11 @@
+description = "flux"
+test        = "flux --version"
+binaries    = ["flux"]
+
+version "0.23.0" {
+  source = "https://github.com/fluxcd/flux2/releases/download/v${version}/flux_${version}_${os}_${arch}.tar.gz"
+
+  auto-version {
+    github-release = "fluxcd/flux2"
+  }
+}


### PR DESCRIPTION
CLI for the flux Kubernetes framework https://fluxcd.io/

I tried to follow what was done for gotestsum (https://github.com/cashapp/hermit-packages/pull/69) but I didn't see any testing documentation so I haven't tested this locally.

I validated the source URL against the release format (https://github.com/fluxcd/flux2/releases/tag/v0.23.0).