### PR TITLE
Add package for kustomize cli

### DIFF
--- a/kustomize.hcl
+++ b/kustomize.hcl
@@ -1,0 +1,12 @@
+description = "kustomize"
+test = "kustomize version"
+binaries = ["kustomize"]
+
+version "4.4.1" {
+  source = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${version}/kustomize_v${version}_${os}_${arch}.tar.gz"
+
+  auto-version {
+    github-release = "kubernetes-sigs/kustomize"
+    version-pattern = "kustomize/(.*)"
+  }
+}

--- a/kustomize.hcl
+++ b/kustomize.hcl
@@ -7,6 +7,6 @@ version "4.4.1" {
 
   auto-version {
     github-release = "kubernetes-sigs/kustomize"
-    version-pattern = "kustomize/(.*)"
+    version-pattern = "kustomize/v(.*)"
   }
 }


### PR DESCRIPTION
CLI for the kustomize Kubernetes framework https://kustomize.io/

I tried to follow what was done for gotestsum (https://github.com/cashapp/hermit-packages/pull/69).

I validated the source URL against the release format (https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize/v4.4.1).