### PR TITLE
Add package for dyff cli

### DIFF
--- a/dyff.hcl
+++ b/dyff.hcl
@@ -1,0 +1,11 @@
+description = "dyff"
+test = "dyff version"
+binaries = ["dyff"]
+
+version "1.4.6" {
+  source = "https://github.com/homeport/dyff/releases/download/v${version}/dyff_${version}_${os}_${arch}.tar.gz"
+
+  auto-version {
+    github-release = "homeport/dyff"
+  }
+}


### PR DESCRIPTION
CLI for the dyff tool https://github.com/homeport/dyff.

I tried to follow what was done for gotestsum (https://github.com/cashapp/hermit-packages/pull/69).

I validated the source URL against the release format (https://github.com/homeport/dyff/releases/tag/v1.4.6).