### PR TITLE
fix: svu darwin release

### DIFF
--- a/svu.hcl
+++ b/svu.hcl
@@ -2,10 +2,16 @@ description = "Semantic Version Util is a tool to manage semantic versions at ea
 test = "svu --version"
 binaries = ["svu"]
 
-version "1.8.0" "1.9.0" {
+version "1.9.0" {
   source = "https://github.com/caarlos0/svu/releases/download/v${version}/svu_${version}_${os}_${arch}.tar.gz"
-
+  platform "darwin" {
+    source = "https://github.com/caarlos0/svu/releases/download/v${version}/svu_${version}_${os}_all.tar.gz"
+  }
   auto-version {
     github-release = "caarlos0/svu"
   }
+}
+
+version "1.8.0"{
+  source = "https://github.com/caarlos0/svu/releases/download/v${version}/svu_${version}_${os}_${arch}.tar.gz"
 }


### PR DESCRIPTION
for svu v1.9 onwards seems like they started to pack all darwin binaries in `darwin_all` instead of `darwin_{arch}`.
This PR will fix this issue on versions since v1.9 

ref: https://github.com/caarlos0/svu/releases/