### PR TITLE
xcodegen 2.26.0

### DIFF
--- a/xcodegen.hcl
+++ b/xcodegen.hcl
@@ -1,0 +1,14 @@
+description = "A Swift command line tool for generating your Xcode project"
+test = "xcodegen --version"
+strip = 1
+binaries = ["bin/xcodegen"]
+
+darwin {
+  source = "https://github.com/yonaskolb/XcodeGen/releases/download/${version}/xcodegen.zip"
+}
+
+version "2.26.0" {
+  auto-version {
+    github-release = "yonaskolb/XcodeGen"
+  }
+}


### PR DESCRIPTION
xcodegen normally installs via homebrew and puts files in `/usr/local/share/xcodegen/SettingPresets`. I'm not sure if this absence will affect a Hermit installation.

Consider this a WIP as I test this on my project.