### PR TITLE
terraform: Add auto-version

### DIFF
--- a/terraform.hcl
+++ b/terraform.hcl
@@ -4,13 +4,24 @@ binaries    = ["terraform"]
 test        = "terraform --version"
 
 darwin {
-  source      = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_amd64.zip"
+  source      = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${arch}.zip"
 }
 
 linux {
   source      = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${arch}.zip"
 }
 
-version "0.11.15" "0.12.31" "0.13.7" "0.14.10" "0.14.11" "0.15.0" "0.15.3" "0.15.5" "1.0.0" "1.0.2" "1.0.11" "1.1.0" "1.1.1" "1.1.2" "1.1.3" "1.1.4" "1.1.5" "1.1.6" "1.1.7" {
+version "0.11.15" "0.12.31" "0.13.7" "0.14.10" "0.14.11" "0.15.0" "0.15.3" "0.15.5" "1.0.0" {
+  platform darwin {
+    # No Darwin ARM64 until v1.0.2
+    source = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_amd64.zip"
+  }
 }
+
+version "1.0.2" "1.0.11" "1.1.0" "1.1.1" "1.1.2" "1.1.3" "1.1.4" "1.1.5" "1.1.6" "1.1.7" {
+  auto-version {
+    github-release = "hashicorp/terraform"
+  }
+}
+
 


### PR DESCRIPTION
Enable `auto-version` for terraform. Split the versions at pre-1.0.2 and
1.0.2+ as 1.0.2 is the first version with Darwin ARM64 binaries.

Link: https://releases.hashicorp.com/terraform
Link: https://github.com/hashicorp/terraform/releases