### PR TITLE
fix: switch rust to use gnu instead of musl

### DIFF
--- a/rust.hcl
+++ b/rust.hcl
@@ -12,7 +12,7 @@ darwin {
 }
 
 linux {
-  source = "https://static.rust-lang.org/dist/rust-${version}-x86_64-unknown-linux-musl.tar.xz"
+  source = "https://static.rust-lang.org/dist/rust-${version}-x86_64-unknown-linux-gnu.tar.xz"
 }
 
 channel "nightly" {
@@ -23,7 +23,7 @@ channel "nightly" {
   }
 
   linux {
-    source = "https://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-musl.tar.xz"
+    source = "https://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.xz"
   }
 }
 


### PR DESCRIPTION
The Rust team defines different tiers of support for different platforms: https://doc.rust-lang.org/rustc/platform-support.html

* Tier 1 targets can be thought of as “guaranteed to work”. The Rust project builds official binary releases for each tier 1 target, and automated testing ensures that each tier 1 target builds and passes tests after each change.
* Tier 2 targets can be thought of as “guaranteed to build”. The Rust project builds official binary releases for each tier 2 target, and automated builds ensure that each tier 2 target builds after each change. Automated tests are not always run so it’s not guaranteed to produce a working build, but tier 2 targets often work to quite a good degree and patches are always welcome!

Unfortunately, for the rust hermit package, it uses the tier 2 `x86_64-unknown-linux-musl`, instead of the tier 1 `x86_64-unknown-linux-gnu`. While the former is workable (with a lot of additional packages/libraries) on Alpine linux, given that you know how to configure musl/gcompat/dynamic linkers, the later works out of the box on development images like ubuntu, and has more complete support along with other dependencies, and using the GNU gcc compiler/linker.