### PR TITLE
azcopy: add initial manifest

### DIFF
--- a/azcopy.hcl
+++ b/azcopy.hcl
@@ -1,0 +1,22 @@
+description = "A command-line utility that you can use to copy blobs or files to or from an Azure storage account."
+
+binaries = ["azcopy_${os}_amd64_${version}/azcopy"]
+test = "azcopy --version"
+
+version "10.14.1" {
+  vars = {
+    release_date: "20220315"
+  }
+}
+
+platform "linux" {
+  source = "https://azcopyvnext.azureedge.net/release${release_date}/azcopy_${os}_amd64_${version}.tar.gz"
+}
+
+platform "darwin" {
+  source = "https://azcopyvnext.azureedge.net/release${release_date}/azcopy_${os}_amd64_${version}.zip"
+}
+
+platform "windows" {
+  source = "https://azcopyvnext.azureedge.net/release${release_date}/azcopy_${os}_amd64_${version}.zip"
+}


### PR DESCRIPTION
This is my first ever point of contact with Hermit, so I may not be following the best practices in terms of creating a solid manifest file. If there's anything terribly wrong, then please do let me know. Verified with:

```console
$ hermit test azcopy --trace --debug
info:validate: Validating azcopy-10.14.1
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_linux_amd64_10.14.1.tar.gz
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
info:validate: Validating azcopy@latest
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_linux_amd64_10.14.1.tar.gz
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
info:validate: Validating azcopy@10
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_linux_amd64_10.14.1.tar.gz
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
info:validate: Validating azcopy@10.14
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_linux_amd64_10.14.1.tar.gz
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
trace: HEAD https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip
debug:azcopy-10.14.1:exec: /home/usrme/.cache/hermit/pkg/azcopy-10.14.1/azcopy_linux_amd64_10.14.1/azcopy --version
debug: azcopy version 10.14.1
```

One thing that stuck out to me was why it's hitting "https://azcopyvnext.azureedge.net/release20220315/azcopy_darwin_amd64_10.14.1.zip" twice with each validation run. Hopefully someone can shed some light on that as well.