### PR TITLE
add goproxy

### DIFF
--- a/goproxy.hcl
+++ b/goproxy.hcl
@@ -1,0 +1,26 @@
+binaries = []
+
+platform "darwin" "amd64" {
+  source = "https://github.com/goproxy/goproxy/releases/download/v${version}/goproxy_${version}_${os}_${arch}.tar.gz"
+}
+
+platform "darwin" "arm64" {
+  source = "https://github.com/goproxy/goproxy/releases/download/v${version}/goproxy_${version}_${os}_${arch}.tar.gz"
+}
+
+platform "linux" "amd64" {
+  source = "https://github.com/goproxy/goproxy/releases/download/v${version}/goproxy_${version}_${os}_${arch}.tar.gz"
+}
+
+description = "A minimalist Go module proxy handler."
+homepage = "https://pkg.go.dev/github.com/goproxy/goproxy"
+
+version "0.10.2" {
+  auto-version {
+    github-release = "goproxy/goproxy"
+
+    html {
+    }
+  }
+}
+


### PR DESCRIPTION
this PR adds goproxy via 

```
hermit manifest create https://github.com/goproxy/goproxy/releases/download/v0.10.2/goproxy_0.10.2_linux_amd64.tar.gz > goproxy.hcl
```