### PR TITLE
Parametrize shellcheck.hcl with the right xarch

### DIFF
--- a/shellcheck.hcl
+++ b/shellcheck.hcl
@@ -2,7 +2,7 @@ description = "A static analysis tool for shell scripts"
 test = "shellcheck --version"
 binaries = ["shellcheck"]
 strip = 1
-source = "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${os}.x86_64.tar.xz"
+source = "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${os}.${xarch}.tar.xz"
 
 version "0.7.1" "0.7.2" "0.8.0" {
   auto-version {


### PR DESCRIPTION
I'm using `xarch` instead of `arch`, following the documentation here:

https://cashapp.github.io/hermit/packaging/reference/#variable-interpolation

> `arch`: The system's CPU architecture as reported by Go.
> `xarch`: An alternate mapping of ${arch} where amd64=>x86_64, i386=>386, and arm64=>aarch64.