### PR TITLE
Python3 on linux arm64 doesn't support pgo => needs a different source url

### DIFF
--- a/python3.hcl
+++ b/python3.hcl
@@ -23,6 +23,11 @@ platform linux {
   source = "https://github.com/indygreg/python-build-standalone/releases/download/${release_date}/cpython-${version}+${release_date}-${xarch}-unknown-linux-gnu-pgo+lto-full.tar.zst"
 }
 
+// Linux arm64 has no pgo
+platform linux arm64 {
+  source = "https://github.com/indygreg/python-build-standalone/releases/download/${release_date}/cpython-${version}+${release_date}-${xarch}-unknown-linux-gnu-lto-full.tar.zst"
+}
+
 // Older releases had a slightly different URL template and no arm64 builds on Mac.
 version "3.8.10" "3.9.5" {
   platform darwin {


### PR DESCRIPTION
Python3 on linux arm64 has no pgo, so a a different source url is required