### PR TITLE
Rust linux source url should include ${xarch}

### DIFF
--- a/rust.hcl
+++ b/rust.hcl
@@ -22,7 +22,7 @@ channel "nightly" {
   }
 
   linux {
-    source = "https://static.rust-lang.org/dist/rust-nightly-${xarc}-unknown-linux-gnu.tar.xz"
+    source = "https://static.rust-lang.org/dist/rust-nightly-${xarch}-unknown-linux-gnu.tar.xz"
   }
 }
 

--- a/rust.hcl
+++ b/rust.hcl
@@ -11,7 +11,7 @@ darwin {
 }
 
 linux {
-  source = "https://static.rust-lang.org/dist/rust-${version}-x86_64-unknown-linux-gnu.tar.xz"
+  source = "https://static.rust-lang.org/dist/rust-${version}-${xarch}-unknown-linux-gnu.tar.xz"
 }
 
 channel "nightly" {
@@ -22,7 +22,7 @@ channel "nightly" {
   }
 
   linux {
-    source = "https://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.xz"
+    source = "https://static.rust-lang.org/dist/rust-nightly-${xarc}-unknown-linux-gnu.tar.xz"
   }
 }
 


### PR DESCRIPTION
Rust source url should contain ${xarch} as a parameter, rather than being hardcoded to x86_64