### PR TITLE
gotestfmt is moving to the GoTestTools org

### DIFF
--- a/gotestfmt.hcl
+++ b/gotestfmt.hcl
@@ -1,12 +1,12 @@
 binaries = ["gotestfmt"]
 description = "go test output for humans"
-homepage = "https://debugged.it/projects/gotestfmt/"
+homepage = "https://github.com/GoTestTools/gotestfmt/"
 
-source = "https://github.com/haveyoudebuggedit/gotestfmt/releases/download/v${version}/gotestfmt_${version}_${os}_${arch}.tar.gz"
+source = "https://github.com/GoTestTools/gotestfmt/releases/download/v${version}/gotestfmt_${version}_${os}_${arch}.tar.gz"
 
-version "2.3.2" {
+version "2.4.0" {
   auto-version {
-    github-release = "haveyoudebuggedit/gotestfmt"
+    github-release = "GoTestTools/gotestfmt"
   }
 }
 


### PR DESCRIPTION
gotestfmt is moving to the GoTestTools organization, please update your references. See the [announcement/release here](https://github.com/GoTestTools/gotestfmt/discussions/46).