### PR TITLE
fix: test changed packages when auto-versioning

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -8,19 +8,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Init Hermit
-        run: |
-          ./bin/hermit env -r >> $GITHUB_ENV
+        run: ./bin/hermit env -r >> $GITHUB_ENV
       - name: Auto-version
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_VERSIONING }}
         run: |
           set -xe
           hermit -d manifest auto-version *.hcl
-          if ! git diff --exit-code; then
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git config --global user.name "github-actions[bot]"
-            git commit -am   "Auto-versioned: $(git diff --name-only | paste -s -d ' ' -)"
-            git push
-          else
+          if git diff --exit-code ${{ github.event.pull_request.base.sha }}; then
             echo "No change"
+            exit 0
           fi
+          for pkg in $(git diff --name-only ${{ github.event.pull_request.base.sha }} | fgrep .hcl | cut -d. -f1 | xargs -I{} -n1 hermit search -s '^{}$' | grep -v '@'); do echo $pkg; hermit test -t $pkg; hermit clean -tp; done
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git commit -am   "Auto-versioned: $(git diff --name-only | paste -s -d ' ' -)"
+          git push


### PR DESCRIPTION
There is no good way of testing this, so it will just have to wait until the next run. Not a big deal.