### PR TITLE
docs(azcopy.hcl): add comments explaining how to find out latest version/date

### DIFF
--- a/azcopy.hcl
+++ b/azcopy.hcl
@@ -4,6 +4,17 @@ binaries = ["azcopy_${os}_amd64_${version}/azcopy"]
 test = "azcopy --version"
 repository = "https://github.com/Azure/azure-storage-azcopy"
 
+// To find out what the latest version and release date is
+//
+// https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10#download-azcopy
+//
+// $ curl -sLI https://aka.ms/downloadazcopy-v10-linux | grep "Location"
+// Location: https://azcopyvnext.azureedge.net/release20221005/azcopy_linux_amd64_10.16.1.tar.gz
+//
+// -s: silent or quiet mode
+// -L: follow redirections
+// -I: fetch headers only
+
 version "10.14.1" {
   vars = {
     release_date: "20220315"


### PR DESCRIPTION
It's not at all obvious from the repository and someone would have to go through the trouble of figuring this out if they wanted to add a new version to the manifest instead of me.