### PR TITLE
Remove runtime dep, which conflicts in cases of private packages repos.

### DIFF
--- a/kscript.hcl
+++ b/kscript.hcl
@@ -1,5 +1,4 @@
 description = "Scripting extensions for kotlin (inclusions and dependencies)"
-runtime-dependencies = ["openjre-17.0.4.1_1", "kotlin-1.7.20"]
 requires = ["jre", "kotlin"]
 source = "https://github.com/kscripting/kscript/releases/download/v${version}/kscript-${version}-bin.zip"
 binaries = ["bin/kscript"]


### PR DESCRIPTION
Conflicts with internal private definitions of openjre, when used with an internal private hermit-packages repo.