### PR TITLE
tinygo: Don't install wasm-opt binary

### DIFF
--- a/tinygo.hcl
+++ b/tinygo.hcl
@@ -1,6 +1,6 @@
 description = "Go compiler for small places. Microcontrollers, WebAssembly (WASM/WASI), and command-line tools. Based on LLVM."
 homepage = "https://tinygo.org"
-binaries = ["bin/*"]
+binaries = ["bin/tinygo"]
 strip = 1
 requires = ["go", "binaryen"]
 source = "https://github.com/tinygo-org/tinygo/releases/download/v${version}/tinygo${version}.${os}-amd64.tar.gz"


### PR DESCRIPTION
Only install the tinygo binary and not wasm-opt as wasm-opt is also in
the dependency package `binaryen`. On Linux, the tinygo release contains
`wasm-opt` but Mac/Darwin does not, which is why this probably not
noticed before.

    > tar tvf tinygo0.25.0.linux-amd64.tar.gz | grep /bin/
    drwxr-xr-x root/root         0 2022-08-03 06:04 tinygo/bin/
    -rwxr-xr-x root/root  17360056 2022-08-03 06:02 tinygo/bin/wasm-opt
    -rwxr-xr-x root/root 138802272 2022-08-03 06:04 tinygo/bin/tinygo

    > tar tvf tinygo0.25.0.darwin-amd64.tar.gz | grep /bin/
    drwxr-xr-x runner/staff      0 2022-08-03 05:53 tinygo/bin/
    -rwxr-xr-x runner/staff 115737032 2022-08-03 05:51 tinygo/bin/tinygo

Trying to install tinygo on Linux gives the following:

    > hermit install tinygo
    info:tinygo-0.26.0:install: Installing tinygo-0.26.0
    info:binaryen-108:install: Installing binaryen-108

    fatal:hermit: binaryen-108 can not be installed, the following binaries already exist: wasm-opt