### PR TITLE
Remove go requirement from mage as it forces a go upgrade

### DIFF
--- a/mage.hcl
+++ b/mage.hcl
@@ -1,6 +1,5 @@
 description = "A make/rake-like dev tool using Go"
 binaries = ["mage"]
-requires = ["go"]
 sha256-source = "https://github.com/magefile/mage/releases/download/v${version}/mage_${version}_checksums.txt"
 
 platform "darwin" "amd64" {


### PR DESCRIPTION
See https://github.com/cashapp/hermit/issues/195