### PR TITLE
arm: updates arm-gnu-toolchain and adds xpack alternative

### DIFF
--- a/arm-gnu-toolchain-xpack.hcl
+++ b/arm-gnu-toolchain-xpack.hcl
@@ -1,0 +1,22 @@
+description = "GNU ARM Embedded GDB with Python3"
+test = "arm-none-eabi-gcc --version"
+binaries = ["bin/arm-none-eabi-*"]
+strip = 1
+
+platform "darwin" "arm64" {
+  source = "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v${version}/xpack-arm-none-eabi-gcc-${version}-darwin-arm64.tar.gz"
+}
+
+platform "darwin" "amd64" {
+  source = "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v${version}/xpack-arm-none-eabi-gcc-${version}-darwin-x64.tar.gz"
+}
+
+platform "linux" "amd64" {
+  source = "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v${version}/xpack-arm-none-eabi-gcc-${version}-linux-x64.tar.gz"
+}
+
+version "11.3.1-1.1" "12.2.1-1.2" "12.3.1-1.2" "13.2.1-1.1" {
+  auto-version {
+    github-release = "xpack-dev-tools/arm-none-eabi-gcc-xpack"
+  }
+}


### PR DESCRIPTION
Updates `arm-gnu-toolchain` to add `10.3-2021.10` and `11.3.rel1` [releases](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads). Official ARM releases are split across [two](https://developer.arm.com/downloads/-/gnu-rm) [sites](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) now, so comments have been added explaining which release site the versions come from.

Also added is an alternative arm toolchain provider `arm-gnu-toolchain-xpack`. The [xPack releases](https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases) have some benefits such as `arm-none-eabi-gdb-py3`, native `darwin-aarch64` builds and consistent semver and arch/os release naming.