### PR TITLE
chore: add gradle 7.6

### DIFF
--- a/gradle.hcl
+++ b/gradle.hcl
@@ -29,6 +29,9 @@ version "7.4.2" {
 version "7.5" {
 }
 
+version "7.6" {
+}
+
 sha256sums = {
   "https://services.gradle.org/distributions/gradle-6.7-bin.zip": "8ad57759019a9233dc7dc4d1a530cefe109dc122000d57f7e623f8cf4ba9dfc4",
   "https://services.gradle.org/distributions/gradle-6.8.3-bin.zip": "7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205",
@@ -38,4 +41,5 @@ sha256sums = {
   "https://services.gradle.org/distributions/gradle-7.3.2-bin.zip": "23b89f8eac363f5f4b8336e0530c7295c55b728a9caa5268fdd4a532610d5392",
   "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip": "29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda",
   "https://services.gradle.org/distributions/gradle-7.5-bin.zip": "cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2",
+  "https://services.gradle.org/distributions/gradle-7.6-bin.zip": "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b",
 }


### PR DESCRIPTION
SHA256 sum taken from https://services.gradle.org/distributions/gradle-7.6-bin.zip.sha256