### PR TITLE
Set PIP_CACHE_DIR in python3.hcl

### DIFF
--- a/python3.hcl
+++ b/python3.hcl
@@ -4,6 +4,7 @@ binaries = ["install/bin/pip3", "install/bin/python3"]
 test = "python3 -m pip install flake8"
 env = {
   "PYTHONPYCACHEPREFIX": "${HERMIT_ENV}/.hermit/python/cache",
+  "PIP_CACHE_DIR": "${HERMIT_ENV}/.hermit/python/cache/pip",
   "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
   "PATH": "${HERMIT_ENV}/.hermit/python/bin:${PATH}",
 }

--- a/python3.hcl
+++ b/python3.hcl
@@ -4,7 +4,7 @@ binaries = ["install/bin/pip3", "install/bin/python3"]
 test = "python3 -m pip install flake8"
 env = {
   "PYTHONPYCACHEPREFIX": "${HERMIT_ENV}/.hermit/python/cache",
-  "PIP_CACHE_DIR": "${HERMIT_ENV}/.hermit/python/cache/pip",
+  "PIP_CACHE_DIR": "${PYTHONPYCACHEPREFIX}/pip",
   "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
   "PATH": "${HERMIT_ENV}/.hermit/python/bin:${PATH}",
 }

--- a/python3.hcl
+++ b/python3.hcl
@@ -4,7 +4,7 @@ binaries = ["install/bin/pip3", "install/bin/python3"]
 test = "python3 -m pip install flake8"
 env = {
   "PYTHONPYCACHEPREFIX": "${HERMIT_ENV}/.hermit/python/cache",
-  "PIP_CACHE_DIR": "${PYTHONPYCACHEPREFIX}/pip",
+  "PIP_CACHE_DIR": "${HERMIT_ENV}/.hermit/python/cache/pip",
   "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
   "PATH": "${HERMIT_ENV}/.hermit/python/bin:${PATH}",
 }


### PR DESCRIPTION
This will make sure cache files are stored under `.hermit` folder, similar to what other toolchains like Rust is doing.

Feedback/suggestions welcomed.