### PR TITLE
Remove commas in just.hcl

### DIFF
--- a/just.hcl
+++ b/just.hcl
@@ -11,7 +11,7 @@ platform "darwin" {
   source = "https://github.com/casey/just/releases/download/${version}/just-${version}-${xarch}-apple-darwin.tar.gz"
 }
 
-version "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0" {
+version "1.2.0" "1.3.0" "1.4.0" "1.5.0" "1.6.0" "1.7.0" "1.8.0" "1.9.0" {
   auto-version {
     github-release = "casey/just"
   }


### PR DESCRIPTION
I made a mistake in #262, the commas make `just` not installable now. `hermit test just` passes with this change.
