### PR TITLE
Add Tekton CLI

### DIFF
--- a/tekton-cli.hcl
+++ b/tekton-cli.hcl
@@ -1,0 +1,30 @@
+description = "A CLI for interacting with Tekton!"
+homepage = "https://github.com/tektoncd/cli"
+source = "https://github.com/tektoncd/cli/releases/download/v${version}/tkn_${version}_${os}_${arch_}.tar.gz"
+binaries = ["tkn"]
+test = "tkn version"
+
+platform "darwin" {
+  vars = {
+    "arch_": "all",
+  }
+}
+
+platform "linux" "amd64" {
+  vars = {
+    "arch_": "x86_64",
+  }
+}
+
+platform "linux" "arm64" {
+  vars = {
+    "arch_": "${arch}",
+  }
+}
+
+
+version "0.29.0" {
+  auto-version {
+    github-release = "tektoncd/cli"
+  }
+}


### PR DESCRIPTION
This commit adds the [Tekton CLI tool][0] to interact with [Tekton Pipelines][1].

[0]: https://github.com/tektoncd/cli
[1]: https://tekton.dev/
