### PR TITLE
fix: rename protoc-gen-go-vtproto binary

### DIFF
--- a/protoc-gen-go-vtproto.hcl
+++ b/protoc-gen-go-vtproto.hcl
@@ -6,6 +6,14 @@ source = "https://github.com/cashapp/hermit-build/releases/download/go-tools/pro
 version "0.4.0" {
 }
 
+on "unpack" {
+  rename {
+    from = "${root}/protoc-gen-go-vtproto-v${version}-${os}-${arch}"
+    to = "${root}/protoc-gen-go-vtproto"
+  }
+}
+
+
 sha256sums = {
   "https://github.com/cashapp/hermit-build/releases/download/go-tools/protoc-gen-go-vtproto-v0.4.0-darwin-amd64.bz2": "e6c903361a88d74cde0cd97ff352096bf0a32dc6c27ce7a8c33b0b40d4da2a17",
   "https://github.com/cashapp/hermit-build/releases/download/go-tools/protoc-gen-go-vtproto-v0.4.0-darwin-arm64.bz2": "b24272b5941a99deeb53b044a32e45004cbe439af3c7ac25814bbfaf00d12f87",


### PR DESCRIPTION
```
> hermit install protoc-gen-go-vtproto
info:protoc-gen-go-vtproto-0.4.0:install: Installing protoc-gen-go-vtproto-0.4.0
████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ 1/1    100.0%

fatal:hermit: protoc-gen-go-vtproto-0.4.0: failed to find binaries "/Users/chua/Library/Caches/hermit/pkg/protoc-gen-go-vtproto-0.4.0/protoc-gen-go-vtproto"

> ls /Users/chua/Library/Caches/hermit/pkg/protoc-gen-go-vtproto-0.4.0
protoc-gen-go-vtproto-v0.4.0-darwin-arm64
```