### PR TITLE
fix: podman linux path rename

### DIFF
--- a/podman.hcl
+++ b/podman.hcl
@@ -9,11 +9,11 @@ platform "darwin" {
 
 platform "linux" {
   binaries = ["podman"]
-  source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz"
+  source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz"
 
   on "unpack" {
     rename {
-      from = "${root}/podman-remote-static"
+      from = "${root}/podman-remote-static-linux_${arch}"
       to = "${root}/podman"
     }
   }
@@ -26,6 +26,18 @@ version "3.3.1" "3.4.0" "3.4.1" "3.4.2" "3.4.4" {
     source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin.zip"
     strip = 1
   }
+
+  platform "linux" {
+    binaries = ["podman"]
+    source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz"
+
+    on "unpack" {
+      rename {
+        from = "${root}/podman-remote-static"
+        to = "${root}/podman"
+      }
+    }
+  }
 }
 
 version "4.0.2" "4.0.3" "4.1.0" "4.1.1" "4.2.0" "4.2.1" "4.3.0" "4.3.1" {
@@ -33,6 +45,18 @@ version "4.0.2" "4.0.3" "4.1.0" "4.1.1" "4.2.0" "4.2.1" "4.3.0" "4.3.1" {
     github-release = "containers/podman"
     ignore-invalid-versions = true
     version-pattern = "^v([4-9]\\.[0-9]+\\.[0-9]+)$"
+  }
+
+  platform "linux" {
+    binaries = ["podman"]
+    source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz"
+
+    on "unpack" {
+      rename {
+        from = "${root}/podman-remote-static"
+        to = "${root}/podman"
+      }
+    }
   }
 }
 

--- a/podman.hcl
+++ b/podman.hcl
@@ -1,6 +1,6 @@
 description = "A tool for managing OCI containers and pods."
-
 sha256-source = "https://github.com/containers/podman/releases/download/v${version}/shasums"
+
 platform "darwin" {
   source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin_${arch}.zip"
   strip = 1
@@ -41,6 +41,20 @@ version "3.3.1" "3.4.0" "3.4.1" "3.4.2" "3.4.4" {
 }
 
 version "4.0.2" "4.0.3" "4.1.0" "4.1.1" "4.2.0" "4.2.1" "4.3.0" "4.3.1" {
+  platform "linux" {
+    binaries = ["podman"]
+    source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz"
+
+    on "unpack" {
+      rename {
+        from = "${root}/podman-remote-static"
+        to = "${root}/podman"
+      }
+    }
+  }
+}
+
+version "4.4.0" {
   auto-version {
     github-release = "containers/podman"
     ignore-invalid-versions = true

--- a/podman.hcl
+++ b/podman.hcl
@@ -7,18 +7,6 @@ platform "darwin" {
   binaries = ["usr/bin/podman"]
 }
 
-platform "linux" {
-  binaries = ["podman"]
-  source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz"
-
-  on "unpack" {
-    rename {
-      from = "${root}/podman-remote-static-linux_${arch}"
-      to = "${root}/podman"
-    }
-  }
-}
-
 version "3.3.1" "3.4.0" "3.4.1" "3.4.2" "3.4.4" {
   binaries = ["podman"]
 
@@ -54,7 +42,7 @@ version "4.0.2" "4.0.3" "4.1.0" "4.1.1" "4.2.0" "4.2.1" "4.3.0" "4.3.1" {
   }
 }
 
-version "4.4.0" {
+version "4.4.0" "4.4.1" {
   auto-version {
     github-release = "containers/podman"
     ignore-invalid-versions = true
@@ -63,11 +51,11 @@ version "4.4.0" {
 
   platform "linux" {
     binaries = ["podman"]
-    source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz"
+    source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz"
 
     on "unpack" {
       rename {
-        from = "${root}/podman-remote-static"
+        from = "${root}/podman-remote-static-linux_${arch}"
         to = "${root}/podman"
       }
     }

--- a/podman.hcl
+++ b/podman.hcl
@@ -42,7 +42,7 @@ version "4.0.2" "4.0.3" "4.1.0" "4.1.1" "4.2.0" "4.2.1" "4.3.0" "4.3.1" {
   }
 }
 
-version "4.4.0" "4.4.1" {
+version "4.4.0" {
   auto-version {
     github-release = "containers/podman"
     ignore-invalid-versions = true


### PR DESCRIPTION
The [authversion jobs](https://github.com/cashapp/hermit-packages/actions/workflows/autoversion.yml) have been failing for the last ~week. Here is an example failure:

```
fatal: app/auto_version_cmd.go:30: manifest/digest/digest.go:89: failed to compute digest for podman-4.4.0/linux-amd64: manifest/digest/digest.go:161: state/state.go:324: cache/cache.go:149: https://github.com/containers/podman/releases/download/v4.4.0/podman-remote-static.tar.gz: cache/http.go:88: download failed: 404 Not Found (404)
```
https://github.com/cashapp/hermit-packages/actions/runs/4120270815/jobs/7114826978

I traced the issue back to a change in the artifact names that are uploaded with podman: https://github.com/containers/podman/pull/16667

I think this change to the manifest will fix it.

I tested this locally:

```bash
> docker run -it -v ${PWD}:/hermit-packages ubuntu /bin/bash
> apt-get update && apt-get install curl
> curl -fsSL https://github.com/cashapp/hermit/releases/download/stable/install.sh | /bin/bash
> mkdir hermit-test
> cd hermit-test
> ~/bin/hermit init
...
> . ./bin/activate-hermit
Hermit environment /hermit-test activated
> echo 'sources = ["env:///../hermit-packages"]' > bin/hermit.hcl
> hermit install podman-4.4.0
info:podman-4.4.0:install: Installing podman-4.4.0                                                                                                                                                                    > bin/podman --version
podman version 4.4.0
> hermit install podman-4.3.1
info:podman-4.3.1:uninstall: Uninstalling podman-4.4.0
info:podman-4.3.1:install: Installing podman-4.3.1
> bin/podman --version
podman version 4.3.1
```

I also tested auto-version locally and that appears to be working:

```bash
> hermit manifest auto-version podman.hcl
```

There might be a secondary follow up where the auto-version command shouldn't fail (instead just printing a warning and not updating the manifest) if it's unable to update digests.