### PR TITLE
Add packages trh and tuc

### DIFF
--- a/trh.hcl
+++ b/trh.hcl
@@ -1,0 +1,21 @@
+description = "Thistle Release Helper (TRH)"
+binaries    = ["trh"]
+test        = "trh --version"
+homepage    = "https://docs.thistle.tech/release_helper/overview"
+
+platform "linux" {
+  source = "https://downloads.thistle.tech/embedded-client/${version}/trh-${xarch}-unknown-linux-musl"
+  on unpack {
+    rename { from = "${root}/trh-${xarch}-unknown-linux-musl" to = "${root}/trh" }
+  }
+}
+
+platform "darwin" {
+  source = "https://downloads.thistle.tech/embedded-client/${version}/trh-x86_64-apple-darwin"
+  on unpack {
+    rename { from = "${root}/trh-x86_64-apple-darwin" to = "${root}/trh" }
+  }
+}
+
+version "0.1.5" "0.1.6" "0.1.7" "0.1.8" "0.1.9" "0.1.10" {
+}

--- a/trh.hcl
+++ b/trh.hcl
@@ -1,21 +1,44 @@
 description = "Thistle Release Helper (TRH)"
-binaries    = ["trh"]
-test        = "trh --version"
-homepage    = "https://docs.thistle.tech/release_helper/overview"
+binaries = ["trh"]
+test = "trh --version"
+homepage = "https://docs.thistle.tech/release_helper/overview"
 
 platform "linux" {
   source = "https://downloads.thistle.tech/embedded-client/${version}/trh-${xarch}-unknown-linux-musl"
-  on unpack {
-    rename { from = "${root}/trh-${xarch}-unknown-linux-musl" to = "${root}/trh" }
+
+  on "unpack" {
+    rename {
+      from = "${root}/trh-${xarch}-unknown-linux-musl"
+      to = "${root}/trh"
+    }
   }
 }
 
 platform "darwin" {
   source = "https://downloads.thistle.tech/embedded-client/${version}/trh-x86_64-apple-darwin"
-  on unpack {
-    rename { from = "${root}/trh-x86_64-apple-darwin" to = "${root}/trh" }
+
+  on "unpack" {
+    rename {
+      from = "${root}/trh-x86_64-apple-darwin"
+      to = "${root}/trh"
+    }
   }
 }
 
 version "0.1.5" "0.1.6" "0.1.7" "0.1.8" "0.1.9" "0.1.10" {
+}
+
+sha256sums = {
+  "https://downloads.thistle.tech/embedded-client/0.1.5/trh-x86_64-unknown-linux-musl": "e4200e91b1a89938f483a857055e3490efe84cd1e9c33428ddc4a17bbf406c8d",
+  "https://downloads.thistle.tech/embedded-client/0.1.5/trh-x86_64-apple-darwin": "6228eee20dffc220d1ed46a0916b8982e24518178f50c66c1ab5cb649e6b75d1",
+  "https://downloads.thistle.tech/embedded-client/0.1.6/trh-x86_64-apple-darwin": "22689fc39fe1c56328af78795cf09e692a24f57700c0e943c7b2e32bf9a9e930",
+  "https://downloads.thistle.tech/embedded-client/0.1.6/trh-x86_64-unknown-linux-musl": "524dd7e490f37a8b3986ef19ce0997c81ee77b1c9db144c6eb266224d04ad783",
+  "https://downloads.thistle.tech/embedded-client/0.1.7/trh-x86_64-apple-darwin": "41d2b1b2bb41702f88d1da8d94d6540b34fd988720094daeed89344fa3508624",
+  "https://downloads.thistle.tech/embedded-client/0.1.7/trh-x86_64-unknown-linux-musl": "4fb4f391486f692244f3c27ac8ee4cb1e174837b03809d12e568b6a01fede81b",
+  "https://downloads.thistle.tech/embedded-client/0.1.8/trh-x86_64-apple-darwin": "f7ef27ac6c7754cf359c48ae3570605af3fe060339c573e54fc2871da8e61d46",
+  "https://downloads.thistle.tech/embedded-client/0.1.8/trh-x86_64-unknown-linux-musl": "4814e908f7d48c4dc96c324506fa3e1df0f38da1c2f3db785b320767009b777a",
+  "https://downloads.thistle.tech/embedded-client/0.1.9/trh-x86_64-unknown-linux-musl": "620627d1aa212fa51561774293a317e365d22e018ac7c96364105fac0d525fde",
+  "https://downloads.thistle.tech/embedded-client/0.1.10/trh-x86_64-unknown-linux-musl": "4c73bed0e3e46cc207a399c03876d0d50a35bda01b3a919860cb33f69dde8573",
+  "https://downloads.thistle.tech/embedded-client/0.1.10/trh-x86_64-apple-darwin": "3348e1562c7ddfee98a075a6fe6a48e6c1ed9b897a5bff2bafb1b8520938156b",
+  "https://downloads.thistle.tech/embedded-client/0.1.9/trh-x86_64-apple-darwin": "45d36af9b2b48589d5872f9420e724833b18ad203782f359fd5d361b7186fd25",
 }

--- a/tuc.hcl
+++ b/tuc.hcl
@@ -1,0 +1,22 @@
+description = "Thistle Update Client (TUC)"
+binaries    = ["tuc"]
+test        = "tuc --version"
+homepage    = "https://docs.thistle.tech/update_client/overview"
+
+platform "linux" {
+  source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-${xarch}-unknown-linux-musl"
+  on unpack {
+    rename { from = "${root}/tuc-${xarch}-unknown-linux-musl" to = "${root}/tuc" }
+  }
+}
+
+
+platform "darwin" {
+  source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-x86_64-apple-darwin"
+  on unpack {
+    rename { from = "${root}/tuc-x86_64-apple-darwin" to = "${root}/tuc" }
+  }
+}
+
+version "0.1.5" "0.1.6" "0.1.7" "0.1.8" "0.1.9" "0.1.10" {
+}

--- a/tuc.hcl
+++ b/tuc.hcl
@@ -1,22 +1,44 @@
 description = "Thistle Update Client (TUC)"
-binaries    = ["tuc"]
-test        = "tuc --version"
-homepage    = "https://docs.thistle.tech/update_client/overview"
+binaries = ["tuc"]
+test = "tuc --version"
+homepage = "https://docs.thistle.tech/update_client/overview"
 
 platform "linux" {
   source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-${xarch}-unknown-linux-musl"
-  on unpack {
-    rename { from = "${root}/tuc-${xarch}-unknown-linux-musl" to = "${root}/tuc" }
+
+  on "unpack" {
+    rename {
+      from = "${root}/tuc-${xarch}-unknown-linux-musl"
+      to = "${root}/tuc"
+    }
   }
 }
 
-
 platform "darwin" {
   source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-x86_64-apple-darwin"
-  on unpack {
-    rename { from = "${root}/tuc-x86_64-apple-darwin" to = "${root}/tuc" }
+
+  on "unpack" {
+    rename {
+      from = "${root}/tuc-x86_64-apple-darwin"
+      to = "${root}/tuc"
+    }
   }
 }
 
 version "0.1.5" "0.1.6" "0.1.7" "0.1.8" "0.1.9" "0.1.10" {
+}
+
+sha256sums = {
+  "https://downloads.thistle.tech/embedded-client/0.1.5/tuc-x86_64-apple-darwin": "bb33031bd3d56a12a386b8cfd02934a0682880a06b3872982ac8eb43a17cf8ab",
+  "https://downloads.thistle.tech/embedded-client/0.1.6/tuc-x86_64-unknown-linux-musl": "4257eda157661c78ea9bdfb5e37d6e591816f99049c805f9a83563c7fb0969f0",
+  "https://downloads.thistle.tech/embedded-client/0.1.6/tuc-x86_64-apple-darwin": "dcd7426a67be563eea39ad4ee60f444dd25b48ae0318253d99a1a86d064e0cb5",
+  "https://downloads.thistle.tech/embedded-client/0.1.7/tuc-x86_64-unknown-linux-musl": "02823e757715f1798e264b9f57706f8670f98c226bdae1ef74d44d0b1d70fb14",
+  "https://downloads.thistle.tech/embedded-client/0.1.7/tuc-x86_64-apple-darwin": "fb5b5458a20808e4b199818e0afbdd4dc392a0f3f57272e7d4e5bc5598f64977",
+  "https://downloads.thistle.tech/embedded-client/0.1.8/tuc-x86_64-apple-darwin": "604e0e6ad70728db3579832f45debf884a9f40e1df8975f4dec265c456ab48f9",
+  "https://downloads.thistle.tech/embedded-client/0.1.8/tuc-x86_64-unknown-linux-musl": "77c8f27c2a62ba133237246ff738e4695abe3642a5cf3d67f8e3c98c1ac1f757",
+  "https://downloads.thistle.tech/embedded-client/0.1.9/tuc-x86_64-apple-darwin": "d3b5afc6504cdac89561bc656644e7fb2f3bb179d60707864cec9284f66b0564",
+  "https://downloads.thistle.tech/embedded-client/0.1.9/tuc-x86_64-unknown-linux-musl": "606cfdaecdca51762d4b6ec0c09c661c1c14acc547b380155ab24f74f3c56fbd",
+  "https://downloads.thistle.tech/embedded-client/0.1.10/tuc-x86_64-unknown-linux-musl": "decc1ffefbab907edb91c1c255bed9ddf32227e23d97659691eda3984b1a153b",
+  "https://downloads.thistle.tech/embedded-client/0.1.10/tuc-x86_64-apple-darwin": "b6b7b60bd9e8afdb313746545d64a6b494a3c36963a5220edc3359e1e0069d8f",
+  "https://downloads.thistle.tech/embedded-client/0.1.5/tuc-x86_64-unknown-linux-musl": "53ce38a28c84ab94b5eb11f5c7ae9588f3209b8e3665a41c398557ae7b5636a3",
 }


### PR DESCRIPTION
Thistle Release Helper (trh) is a tool to help prepare releases for
device OTA updates. https://docs.thistle.tech/release_helper/overview
    
Thistle Update Client (tuc) is an application running on a device to
take care of OTA updates.
https://docs.thistle.tech/update_client/overview

We also add sha256 digests of trh and tuc binaries, in the second commit.