### PR TITLE
fix: auto-versioning woes

### DIFF
--- a/fd.hcl
+++ b/fd.hcl
@@ -11,13 +11,15 @@ platform "darwin" {
   source = "https://github.com/sharkdp/fd/releases/download/v${version}/fd-v${version}-x86_64-apple-darwin.tar.gz"
 }
 
-version "8.3.2" {
+version "8.3.2" "8.6.0" {
   auto-version {
-    github-release = "skarkdp/fd"
+    github-release = "sharkdp/fd"
   }
 }
 
 sha256sums = {
   "https://github.com/sharkdp/fd/releases/download/v8.3.2/fd-v8.3.2-x86_64-unknown-linux-musl.tar.gz": "ead0af971def922aa36f567fa172a266a73cfee45d0d94098464b500d652fb4b",
   "https://github.com/sharkdp/fd/releases/download/v8.3.2/fd-v8.3.2-x86_64-apple-darwin.tar.gz": "02ce0825231fb370b0711e30933b043761beee46bdcbf0132eba43c3f510db53",
+  "https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-x86_64-unknown-linux-musl.tar.gz": "9fdb370648fb8256fc9a36355c652546bd4c62925babcad80f95f90f74fc81e7",
+  "https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-x86_64-apple-darwin.tar.gz": "f8629345125c130fac82e2ce2bd3aba8cd68f923076081409c9d8791b731693e",
 }

--- a/git-cliff.hcl
+++ b/git-cliff.hcl
@@ -36,9 +36,9 @@ platform "windows" {
 }
 
 version "0.9.2" "0.9.1" "0.9.0" "0.8.1" "0.7.0" "0.6.1" "0.6.0" "0.5.0" "0.4.2" "0.4.1"
-        "0.4.0" {
+        "0.4.0" "1.1.2" {
   auto-version {
-    github-release = "git-cliff/git-cliff"
+    github-release = "orhun/git-cliff"
   }
 }
 
@@ -65,4 +65,6 @@ sha256sums = {
   "https://github.com/orhun/git-cliff/releases/download/v0.8.1/git-cliff-0.8.1-x86_64-unknown-linux-gnu.tar.gz": "2616e47859e52132b1e851a37272146593c7117907b511f4b241864d01866c8a",
   "https://github.com/orhun/git-cliff/releases/download/v0.8.1/git-cliff-0.8.1-x86_64-apple-darwin.tar.gz": "6635348a949a76c24af9a35a1cf082cdab431ff1dc602d303d841bd39e12c992",
   "https://github.com/orhun/git-cliff/releases/download/v0.9.2/git-cliff-0.9.2-x86_64-unknown-linux-gnu.tar.gz": "196f5dd4553fc849aff59f66b13f5bde0685e84115a283de4344e58e208ab874",
+  "https://github.com/orhun/git-cliff/releases/download/v1.1.2/git-cliff-1.1.2-x86_64-unknown-linux-gnu.tar.gz": "ca81ad620bc796d8cd69c24d6bfe7a788de3585ba9dd582e9262e29da1478971",
+  "https://github.com/orhun/git-cliff/releases/download/v1.1.2/git-cliff-1.1.2-x86_64-apple-darwin.tar.gz": "b63a065b4474a7e22351627dc93e55ab7b5cfe7a07dbca186f677499f8428261",
 }

--- a/gotestfmt.hcl
+++ b/gotestfmt.hcl
@@ -3,9 +3,9 @@ description = "go test output for humans"
 homepage = "https://debugged.it/projects/gotestfmt/"
 source = "https://github.com/GoTestTools/gotestfmt/releases/download/v${version}/gotestfmt_${version}_${os}_${arch}.tar.gz"
 
-version "2.3.2" {
+version "2.3.2" "2.4.1" {
   auto-version {
-    github-release = "/GoTestTools/gotestfmt"
+    github-release = "GoTestTools/gotestfmt"
   }
 }
 
@@ -13,4 +13,7 @@ sha256sums = {
   "https://github.com/GoTestTools/gotestfmt/releases/download/v2.3.2/gotestfmt_2.3.2_linux_amd64.tar.gz": "c5aae4dc2a4b0d138d27da0f1c0ae18c744e2788d6caecac50f9e45c3d746393",
   "https://github.com/GoTestTools/gotestfmt/releases/download/v2.3.2/gotestfmt_2.3.2_darwin_amd64.tar.gz": "b5969860a362dd17496a5f47d3e8dee47636e70f8638393e49a771d0e7e4ee2c",
   "https://github.com/GoTestTools/gotestfmt/releases/download/v2.3.2/gotestfmt_2.3.2_darwin_arm64.tar.gz": "7381cb5848e7401232c79f6f3b2f5b56bb792affb253d42b8a41de62b749f16e",
+  "https://github.com/GoTestTools/gotestfmt/releases/download/v2.4.1/gotestfmt_2.4.1_linux_amd64.tar.gz": "f3812e780f3386121307074f7cd0e312c3965683edc7b4588365baf38d7fcb17",
+  "https://github.com/GoTestTools/gotestfmt/releases/download/v2.4.1/gotestfmt_2.4.1_darwin_amd64.tar.gz": "c8e6cb14049f8f06c062f08c0e59a6443c4cb607c9c2bad1a92ba859f0a8af5d",
+  "https://github.com/GoTestTools/gotestfmt/releases/download/v2.4.1/gotestfmt_2.4.1_darwin_arm64.tar.gz": "68ad5ed75332bbe06b832b48cfb07692fb4cc777b767964c82b27bac100cdf87",
 }

--- a/lefthook.hcl
+++ b/lefthook.hcl
@@ -47,9 +47,9 @@ platform "windows" {
 }
 
 version "1.2.1" "1.2.0" "1.1.4" "1.1.3" "1.1.2" "1.1.1" "1.1.0" "1.0.5" "1.0.4" "1.0.3"
-        "1.0.2" "1.0.1" "1.0.0" "0.8.0" "0.7.7" "0.7.6" "0.7.5" "0.7.4" {
+        "1.0.2" "1.0.1" "1.0.0" "0.8.0" "0.7.7" "0.7.6" "0.7.5" "0.7.4" "1.2.9" {
   auto-version {
-    github-release = "lefthook/lefthook"
+    github-release = "evilmartians/lefthook"
   }
 }
 
@@ -108,4 +108,7 @@ sha256sums = {
   "https://github.com/evilmartians/lefthook/releases/download/v1.1.2/lefthook_1.1.2_Linux_x86_64": "2e87812816be055bd2868166777fea3e3c250f720ff90bcbf99402772737f274",
   "https://github.com/evilmartians/lefthook/releases/download/v1.1.3/lefthook_1.1.3_MacOS_arm64": "af2ee08cc95b158ad24314df07970c2333dc1453df8d982dd68b0f92d04ab5d1",
   "https://github.com/evilmartians/lefthook/releases/download/v1.2.0/lefthook_1.2.0_MacOS_x86_64": "56c4dbdfe4fe7e06b63ad081976407355793e8de26b7e3b3c153928553b09e29",
+  "https://github.com/evilmartians/lefthook/releases/download/v1.2.9/lefthook_1.2.9_MacOS_arm64": "542c37fb3bbccf406c6090b7c7da0b1c6bb64c22934956ca24eca90f64953d58",
+  "https://github.com/evilmartians/lefthook/releases/download/v1.2.9/lefthook_1.2.9_Linux_x86_64": "9f3f537ba23b98bfe690a14d96399e97bf76b2e382126f6d39108421926311a7",
+  "https://github.com/evilmartians/lefthook/releases/download/v1.2.9/lefthook_1.2.9_MacOS_x86_64": "e05140f862835ea9d7e42852c42368d4827cbfcda500343ac6d9638a20e28896",
 }

--- a/loki-logcli.hcl
+++ b/loki-logcli.hcl
@@ -10,9 +10,9 @@ on "unpack" {
   }
 }
 
-version "2.4.2" {
+version "2.4.2" "2.7.3" {
   auto-version {
-    github-release = "grafana-loki"
+    github-release = "grafana/loki"
   }
 }
 
@@ -20,4 +20,7 @@ sha256sums = {
   "https://github.com/grafana/loki/releases/download/v2.4.2/logcli-linux-amd64.zip": "68e5e281b4488ad49303cce972e194fe4e186cd519ed8a14db0c28316ad01e05",
   "https://github.com/grafana/loki/releases/download/v2.4.2/logcli-darwin-amd64.zip": "a09f217528bd3598aa6f235d5934c00f3556ad331206adcbe6099305110b2cd7",
   "https://github.com/grafana/loki/releases/download/v2.4.2/logcli-darwin-arm64.zip": "37c5f30206ab3bd8b7c088efd5c81d43b93ca5b96fa7d9403862ec7ef4d7f413",
+  "https://github.com/grafana/loki/releases/download/v2.7.3/logcli-linux-amd64.zip": "d295d510e5eca6f2437acc085aba399ea4274705d1fec436cf916919c75cec45",
+  "https://github.com/grafana/loki/releases/download/v2.7.3/logcli-darwin-amd64.zip": "591d116d7dcecd12a04b0e669017e23b9c6cc3741df3d01e9c94170deaed5e0a",
+  "https://github.com/grafana/loki/releases/download/v2.7.3/logcli-darwin-arm64.zip": "ba5257c0e4295a671fc320af361478da947b30b50687eed80b94f3caeb3b5178",
 }

--- a/loki-promtail.hcl
+++ b/loki-promtail.hcl
@@ -10,9 +10,9 @@ on "unpack" {
   }
 }
 
-version "2.4.2" {
+version "2.4.2" "2.7.3" {
   auto-version {
-    github-release = "grafana-loki"
+    github-release = "grafana/loki"
   }
 }
 
@@ -20,4 +20,7 @@ sha256sums = {
   "https://github.com/grafana/loki/releases/download/v2.4.2/promtail-linux-amd64.zip": "570d1d69c2610f2283f9f758fb028a9d830dc39f75e2134ffa4a125cb7329b9c",
   "https://github.com/grafana/loki/releases/download/v2.4.2/promtail-darwin-amd64.zip": "6f1164a4072bfdcf95d0631e22d4dc8fd3922c1166f8dd4e3ae2fbe599679e4c",
   "https://github.com/grafana/loki/releases/download/v2.4.2/promtail-darwin-arm64.zip": "2de52be9bf9bae65efe5572ebdf66810f531e4045d646ec0166c4c3012b5e6f2",
+  "https://github.com/grafana/loki/releases/download/v2.7.3/promtail-linux-amd64.zip": "608289347504b84be0cd1afb41914c2cc1e318842e88de9d36f7a21c7e60102e",
+  "https://github.com/grafana/loki/releases/download/v2.7.3/promtail-darwin-amd64.zip": "6feeb998ee0469d8d932e6822b84f573483e4736ce6afe0c2bec3afd4b2f9bd5",
+  "https://github.com/grafana/loki/releases/download/v2.7.3/promtail-darwin-arm64.zip": "7af75ccbb361b631aab50084a914d93686e2210314be929491d5172293f23e5e",
 }


### PR DESCRIPTION
should fix these warnings

```
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/fd.hcl": 14:1: https://api.github.com/repos/skarkdp/fd/releases/latest: GitHub API request failed with 404 Not Found
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/git-cliff.hcl": 38:1: https://api.github.com/repos/git-cliff/git-cliff/releases/latest: GitHub API request failed with 404 Not Found
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/gotestfmt.hcl": 6:1: https://api.github.com/repos//GoTestTools/gotestfmt/releases/latest: GitHub API request failed with 404 Not Found
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/hlb.hcl": 13:1: https://api.github.com/repos/openllb/hlb/releases/latest: GitHub API request failed with 404 Not Found
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/lefthook.hcl": 49:1: https://api.github.com/repos/lefthook/lefthook/releases/latest: GitHub API request failed with 404 Not Found
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/loki-logcli.hcl": 13:1: https://api.github.com/repos/grafana-loki/releases/latest: GitHub API request failed with 404 Not Found
warn: could not auto-version "/home/runner/work/hermit-packages/hermit-packages/loki-promtail.hcl": 13:1: https://api.github.com/repos/grafana-loki/releases/latest: GitHub API request failed with 404 Not Found
```