### PR TITLE
fix: `goss.hcl` two bugs

### DIFF
--- a/goss.hcl
+++ b/goss.hcl
@@ -11,8 +11,8 @@ platform "darwin" {
 
   on "unpack" {
     rename {
-      from = "${root}/goss-alpha-${os}-${arch_}.exe"
-      to = "${root}/goss.exe"
+      from = "${root}/goss-alpha-${os}-${arch_}"
+      to = "${root}/goss"
     }
   }
 }
@@ -34,10 +34,12 @@ platform "windows" {
   }
 }
 
-on "unpack" {
-  rename {
-    from = "${root}/goss-${os}-${arch_}"
-    to = "${root}/goss"
+platform "linux" {
+  on "unpack" {
+    rename {
+      from = "${root}/goss-${os}-${arch_}"
+      to = "${root}/goss"
+    }
   }
 }
 


### PR DESCRIPTION
I discovered two bugs (🐛) when I was testing this out.

1. I had accidentally add the `.exe` suffix to the `darwin` platform.
2. I expected `on "unpack" { ... }` in `darwin` to override the base level `on "unpack" { ... }` but it did not.

I missed these in my initial tests because I tested the code, made some updates, and then skipped re-testing. I re-tested after the changes this time.

```
> hermit install goss --trace
info:goss-0.3.21:install: Installing goss-0.3.21
debug:goss-0.3.21:install: From https://github.com/goss-org/goss/releases/download/v0.3.21/goss-alpha-darwin-amd64
debug:goss-0.3.21:install: To /Users/dolan/Library/Caches/hermit/pkg/goss-0.3.21
debug:goss-0.3.21:link: Linking binaries for goss-0.3.21
debug:goss-0.3.21:link: ln -s "hermit" "/Users/dolan/Development/hermit-packages/bin/.goss-0.3.21.pkg"
debug:goss-0.3.21:link: ln -s ".goss-0.3.21.pkg" "/Users/dolan/Development/hermit-packages/bin/goss"
```

Sorry about the bug.