### PR TITLE
Update gum to latest and add auto-version

### DIFF
--- a/gum.hcl
+++ b/gum.hcl
@@ -7,11 +7,17 @@ platform "amd64" {
   source = "https://github.com/charmbracelet/gum/releases/download/v${version}/gum_${version}_${os}_x86_64.tar.gz"
 }
 
-version "0.1.0" {
+version "0.1.0" "0.10.0" {
+  auto-version {
+    github-release = "charmbracelet/gum"
+  }
 }
 
 sha256sums = {
   "https://github.com/charmbracelet/gum/releases/download/v0.1.0/gum_0.1.0_linux_x86_64.tar.gz": "a8ad13621e1b002cc1d52b5b49096f5ba59ac0e3e940dd75af7c5dfde42968ad",
   "https://github.com/charmbracelet/gum/releases/download/v0.1.0/gum_0.1.0_darwin_x86_64.tar.gz": "de400405cf06dac8e8cc8571cfa91ec8c400c9efe86e07a121da44e47e4899b3",
   "https://github.com/charmbracelet/gum/releases/download/v0.1.0/gum_0.1.0_darwin_arm64.tar.gz": "a64696182b6c114af0af869c074c8ac75f3b9f64a399410bbf05527e6f7c5eef",
+  "https://github.com/charmbracelet/gum/releases/download/v0.10.0/gum_0.10.0_Linux_x86_64.tar.gz":"efdc3564afdb7b4b7566b5cab49dd3b82aa9c6c9880c2df1572dff2584d618c5",
+  "https://github.com/charmbracelet/gum/releases/download/v0.10.0/gum_0.10.0_Darwin_x86_64.tar.gz":"41af5678b105d18dc5c9752c8a62ba67e54609846b3299b601c16c8ee84399cd",
+  "https://github.com/charmbracelet/gum/releases/download/v0.10.0/gum_0.10.0_Darwin_arm64.tar.gz":"e1ebddb5321fe5dd57de21f4b0ef97d14915029f3f531b625778aebf9648ff96",
 }


### PR DESCRIPTION
Update gum to latest and add auto-version. Mostly needed for the [multi-select changes in v0.6.0](https://github.com/charmbracelet/gum/releases/tag/v0.6.0).