### PR TITLE
Add trh/tuc 0.1.11, 0.1.12

### DIFF
--- a/trh.hcl
+++ b/trh.hcl
@@ -3,29 +3,52 @@ binaries = ["trh"]
 test = "trh --version"
 homepage = "https://docs.thistle.tech/release_helper/overview"
 
-platform "linux" {
-  source = "https://downloads.thistle.tech/embedded-client/${version}/trh-${xarch}-unknown-linux-musl"
+version "0.1.11" "0.1.12" {
+  platform "linux" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/trh-${version}-${xarch}-unknown-linux-musl"
 
-  on "unpack" {
-    rename {
-      from = "${root}/trh-${xarch}-unknown-linux-musl"
-      to = "${root}/trh"
+    on "unpack" {
+      rename {
+        from = "${root}/trh-${version}-${xarch}-unknown-linux-musl"
+        to = "${root}/trh"
+      }
     }
   }
-}
 
-platform "darwin" {
-  source = "https://downloads.thistle.tech/embedded-client/${version}/trh-x86_64-apple-darwin"
+  platform "darwin" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/trh-${version}-x86_64-apple-darwin"
 
-  on "unpack" {
-    rename {
-      from = "${root}/trh-x86_64-apple-darwin"
-      to = "${root}/trh"
+    on "unpack" {
+      rename {
+        from = "${root}/trh-${version}-x86_64-apple-darwin"
+        to = "${root}/trh"
+      }
     }
   }
 }
 
 version "0.1.5" "0.1.6" "0.1.7" "0.1.8" "0.1.9" "0.1.10" {
+  platform "darwin" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/trh-x86_64-apple-darwin"
+
+    on "unpack" {
+      rename {
+        from = "${root}/trh-x86_64-apple-darwin"
+        to = "${root}/trh"
+      }
+    }
+  }
+
+  platform "linux" "amd64" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/trh-x86_64-unknown-linux-musl"
+
+    on "unpack" {
+      rename {
+        from = "${root}/trh-x86_64-unknown-linux-musl"
+        to = "${root}/trh"
+      }
+    }
+  }
 }
 
 sha256sums = {
@@ -41,4 +64,8 @@ sha256sums = {
   "https://downloads.thistle.tech/embedded-client/0.1.10/trh-x86_64-unknown-linux-musl": "4c73bed0e3e46cc207a399c03876d0d50a35bda01b3a919860cb33f69dde8573",
   "https://downloads.thistle.tech/embedded-client/0.1.10/trh-x86_64-apple-darwin": "3348e1562c7ddfee98a075a6fe6a48e6c1ed9b897a5bff2bafb1b8520938156b",
   "https://downloads.thistle.tech/embedded-client/0.1.9/trh-x86_64-apple-darwin": "45d36af9b2b48589d5872f9420e724833b18ad203782f359fd5d361b7186fd25",
+  "https://downloads.thistle.tech/embedded-client/0.1.11/trh-0.1.11-x86_64-unknown-linux-musl": "a3a792d2fa7b73eb6f7863cc8a8be07b2e6ccf1c2f6499b46a7fe88fd1e5a710",
+  "https://downloads.thistle.tech/embedded-client/0.1.11/trh-0.1.11-x86_64-apple-darwin": "f156e9c39a4b0c5ddc3ed22f4ed10a6f700dd0f162f15f99b6f2a33cdad8d900",
+  "https://downloads.thistle.tech/embedded-client/0.1.12/trh-0.1.12-x86_64-unknown-linux-musl": "96e7709e4d8065746aac84753bb58136090bbd02a4feda559f464d5e248f845a",
+  "https://downloads.thistle.tech/embedded-client/0.1.12/trh-0.1.12-x86_64-apple-darwin": "1cfaa7e2c671e8cc294633534cdd5dcb1acc7210bcca84b4314d4072b19b8345",
 }

--- a/tuc.hcl
+++ b/tuc.hcl
@@ -3,29 +3,52 @@ binaries = ["tuc"]
 test = "tuc --version"
 homepage = "https://docs.thistle.tech/update_client/overview"
 
-platform "linux" {
-  source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-${xarch}-unknown-linux-musl"
+version "0.1.11" "0.1.12" {
+  platform "linux" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-${version}-${xarch}-unknown-linux-musl"
 
-  on "unpack" {
-    rename {
-      from = "${root}/tuc-${xarch}-unknown-linux-musl"
-      to = "${root}/tuc"
+    on "unpack" {
+      rename {
+        from = "${root}/tuc-${version}-${xarch}-unknown-linux-musl"
+        to = "${root}/tuc"
+      }
     }
   }
-}
 
-platform "darwin" {
-  source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-x86_64-apple-darwin"
+  platform "darwin" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-${version}-x86_64-apple-darwin"
 
-  on "unpack" {
-    rename {
-      from = "${root}/tuc-x86_64-apple-darwin"
-      to = "${root}/tuc"
+    on "unpack" {
+      rename {
+        from = "${root}/tuc-${version}-x86_64-apple-darwin"
+        to = "${root}/tuc"
+      }
     }
   }
 }
 
 version "0.1.5" "0.1.6" "0.1.7" "0.1.8" "0.1.9" "0.1.10" {
+  platform "darwin" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-x86_64-apple-darwin"
+
+    on "unpack" {
+      rename {
+        from = "${root}/tuc-x86_64-apple-darwin"
+        to = "${root}/tuc"
+      }
+    }
+  }
+
+  platform "linux" "amd64" {
+    source = "https://downloads.thistle.tech/embedded-client/${version}/tuc-x86_64-unknown-linux-musl"
+
+    on "unpack" {
+      rename {
+        from = "${root}/tuc-x86_64-unknown-linux-musl"
+        to = "${root}/tuc"
+      }
+    }
+  }
 }
 
 sha256sums = {
@@ -41,4 +64,8 @@ sha256sums = {
   "https://downloads.thistle.tech/embedded-client/0.1.10/tuc-x86_64-unknown-linux-musl": "decc1ffefbab907edb91c1c255bed9ddf32227e23d97659691eda3984b1a153b",
   "https://downloads.thistle.tech/embedded-client/0.1.10/tuc-x86_64-apple-darwin": "b6b7b60bd9e8afdb313746545d64a6b494a3c36963a5220edc3359e1e0069d8f",
   "https://downloads.thistle.tech/embedded-client/0.1.5/tuc-x86_64-unknown-linux-musl": "53ce38a28c84ab94b5eb11f5c7ae9588f3209b8e3665a41c398557ae7b5636a3",
+  "https://downloads.thistle.tech/embedded-client/0.1.11/tuc-0.1.11-x86_64-apple-darwin": "0e5732796c5e74d7573843dc0d6d9fc31c3b3b53f49d88dd2dcb2b05e557e6dc",
+  "https://downloads.thistle.tech/embedded-client/0.1.11/tuc-0.1.11-x86_64-unknown-linux-musl": "a3dddad5162370b99b6449380ad9c0d2f2fa7f853678204b761a3ae66a95662a",
+  "https://downloads.thistle.tech/embedded-client/0.1.12/tuc-0.1.12-x86_64-unknown-linux-musl": "7f1103ce2006b921256bddc0fa30a69e379646fbb4d7dac3ed536f701abba39b",
+  "https://downloads.thistle.tech/embedded-client/0.1.12/tuc-0.1.12-x86_64-apple-darwin": "4ca978e9370fe4e4e80b6ed1e8566b5ec1333610eb5a1bfd1d1d3754087e973d",
 }


### PR DESCRIPTION
Starting at version 0.1.11, there's a change in the URL patterns for `trh` and `tuc` artifacts. We adjusted the package manifests to describe both the old and new patterns.

Also run `hermit manifest add-digests tuc.hcl trh.hcl` to add sha256 sums.