### PR TITLE
Auto-refresh HashiCorp package checksums daily

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -15,6 +15,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AUTO_VERSIONING }}
         run: |
           set -xe
+
+          # Clear out and then re-add HashiCorp package digests because they
+          # frequently change due to binaries being republished every few months
+          # Examples:
+          # https://status.hashicorp.com/incidents/xbbwr755y78b
+          # https://status.hashicorp.com/incidents/f7bz2z28w6pv
+          grep --files-with-matches --fixed-strings 'releases.hashicorp.com' *.hcl | while read -r file; do
+            sed -i '' -E '/[a-fA-F0-9]{64}/d' $file
+            hermit manifest add-digests $file
+          done
+
           hermit -d manifest auto-version --update-digests *.hcl
           if git diff --exit-code ${{ github.event.pull_request.base.sha }}; then
             echo "No change"


### PR DESCRIPTION
HashiCorp has been republishing binaries for their tools every few months, and each time that happens the Hermit packages for those tools break due to the digests in the Hermit packages no longer matching the binaries downloaded from HashiCorp's releases website, so users of those Hermit packages see an error like:

```
fatal:hermit: https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_amd64.zip: https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_amd64.zip: checksum 685258b525eae94fb0b406faf661aa056d31666256bf28e625365a251cb89fdc should have been 26afa7cda355fbf32a2b4cfd9122a49132f1b68337691b91f05caa0b1023c388
```

Each time this has happened in the past we have had to update the checksums in the Hermit package manifests for those HashiCorp tools, for example:

1. January 23, 2023: https://status.hashicorp.com/incidents/xbbwr755y78b
    1. Fixed via https://github.com/cashapp/hermit-packages/pull/274, https://github.com/cashapp/hermit-packages/pull/273, and https://github.com/cashapp/hermit-packages/commit/4504a6c2754b1aed0c713262c540ab9774b5f783
2. March 20, 2023: https://status.hashicorp.com/incidents/f7bz2z28w6pv
    1. Fixed via https://github.com/cashapp/hermit-packages/commit/0025beb15175aa0a59af57a17e5b13e4aa7224a8

This PR extends this repo's existing daily `autoversion` GitHub Actions workflow to clear out and then re-add digests of HashiCorp Hermit packages so that we don't have to continue fixing this manually in the future.