### PR TITLE
Add regal

### DIFF
--- a/regal.hcl
+++ b/regal.hcl
@@ -1,0 +1,49 @@
+description = "Regal is a linter for Rego, with the goal of making your Rego magnificent!"
+homepage = "https://github.com/StyraInc/regal"
+binaries = ["regal"]
+
+platform "darwin" {
+  vars = {
+    "os_": "Darwin",
+  }
+}
+
+platform "linux" {
+  vars = {
+    "os_": "Linux",
+  }
+}
+
+platform "amd64" {
+  vars = {
+    "arch_": "x86_64"
+  }
+}
+
+platform "arm64" {
+  vars = {
+    "arch_": "arm64"
+  }
+}
+
+source = "https://github.com/StyraInc/regal/releases/download/v${version}/regal_${os_}_${arch_}"
+
+on "unpack" {
+  rename {
+    from = "${root}/regal_${os_}_${arch_}"
+    to = "${root}/regal"
+  }
+}
+
+version "0.4.0" {
+  auto-version {
+    github-release = "StyraInc/regal"
+  }
+}
+
+sha256sums = {
+  "https://github.com/StyraInc/regal/releases/download/v0.4.0/regal_Darwin_arm64": "a197e927d902ea631b9b43d772be26eecb12fe321bc7adf8cddb8c18d8fdc54e",
+  "https://github.com/StyraInc/regal/releases/download/v0.4.0/regal_Darwin_x86_64": "de24bbb3fe40c182421c8c50e556ffe4cbd3a24cc3bee08f4d894d49b2611a51",
+  "https://github.com/StyraInc/regal/releases/download/v0.4.0/regal_Linux_arm64": "5c087ff18bc4f669ec6d3995b8b27dc68253e2ed036f3f35aa77490095261fd3",
+  "https://github.com/StyraInc/regal/releases/download/v0.4.0/regal_Linux_x86_64": "4d0d822a5a387a5de4ce71ee49272eee896d97e9b6c05b3922cd723b9ec866cc",
+}


### PR DESCRIPTION
Regal ( https://github.com/StyraInc/regal ) is a linter for Rego, the policy language of [Open Policy Agent (OPA)](https://www.openpolicyagent.org/). It was recently released by the maintainers of OPA, and I'd like to get it into Hermit's packages.

```
$ hermit test regal
info:validate: Validating regal-0.4.0
info:validate: Validating regal@latest
info:validate: Validating regal@0
info:validate: Validating regal@0.4

$ hermit install regal
info:regal-0.4.0:install: Installing regal-0.4.0

$ which regal
/Users/minglis/Development/hermit-packages-public/bin/regal

$ regal version
Version:    0.4.0
Go Version: go1.20.5
Platform:   darwin/arm64
Commit:        unknown
Timestamp:  2023-07-04T09:02:54Z
Hostname:   github.actions.local
```

Let me know (or just amend) if there's a better way to achieve the necessary OS/arch variance here. I looked at a few prior examples of `vars` assignment and `on "unpack"`, but I might've missed approaches.

Thanks!