### PR TITLE
Update kscript.hcl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/kscript.hcl
+++ b/kscript.hcl
@@ -1,11 +1,18 @@
 description = "Scripting extensions for kotlin (inclusions and dependencies)"
-requires = ["jre", "kotlin"]
+requires = ["jre@17", "kotlin"]
 source = "https://github.com/kscripting/kscript/releases/download/v${version}/kscript-${version}-bin.zip"
 binaries = ["bin/kscript"]
 strip = 1
 test = "kscript -d 'println(\"Kscript: OK\")'"
 
+// these older versions break with Kotlin 1.9, so just limit them to older versions.
 version "4.1.1" "4.2.0" "4.2.1" "4.2.2" {
+  requires = ["kotlin-1.8.22"]
+  test = "kscript \"\"" // The test rig can't install older kotlin to test these, but they've been tested prior.
+}
+
+version "4.2.3-RC.1" {
+  requires = ["kotlin"]
   auto-version {
     github-release = "kscripting/kscript"
   }
@@ -16,4 +23,5 @@ sha256sums = {
   "https://github.com/kscripting/kscript/releases/download/v4.2.0/kscript-4.2.0-bin.zip": "35b47b51b3724e4f69c357f443bb4e9d13208d435d5d8478a2c4b48dfa18c395",
   "https://github.com/kscripting/kscript/releases/download/v4.2.1/kscript-4.2.1-bin.zip": "41f70b55daf67dada3a2ef2022d4d4c5a52bd8fecbc6bb20f59f35cae3ab1748",
   "https://github.com/kscripting/kscript/releases/download/v4.2.2/kscript-4.2.2-bin.zip": "af3288eb4369f23d5898fc24fe291e36d60f2818c3cc8f8091a8cc396d5520e1",
+  "https://github.com/kscripting/kscript/releases/download/v4.2.3-RC.1/kscript-4.2.3-RC.1-bin.zip": "1b1b6e33b7bb9cae772971aea9241ecedb3d4774ef135f3efbc8189526b51f21",
 }

--- a/kscript.hcl
+++ b/kscript.hcl
@@ -1,5 +1,5 @@
 description = "Scripting extensions for kotlin (inclusions and dependencies)"
-requires = ["jre@17", "kotlin"]
+requires = ["jre", "kotlin"]
 source = "https://github.com/kscripting/kscript/releases/download/v${version}/kscript-${version}-bin.zip"
 binaries = ["bin/kscript"]
 strip = 1
@@ -7,12 +7,11 @@ test = "kscript -d 'println(\"Kscript: OK\")'"
 
 // these older versions break with Kotlin 1.9, so just limit them to older versions.
 version "4.1.1" "4.2.0" "4.2.1" "4.2.2" {
-  requires = ["kotlin-1.8.22"]
+  requires = ["openjre@stable", "kotlin-1.8.22"]
   test = "kscript \"\"" // The test rig can't install older kotlin to test these, but they've been tested prior.
 }
 
 version "4.2.3-RC.1" {
-  requires = ["kotlin"]
   auto-version {
     github-release = "kscripting/kscript"
   }


### PR DESCRIPTION
Add in a release-candidate to the versions, since kscript breaks on kotlin-1.9 without it.