### PR TITLE
chore: add versions `1.15.4`, `1.16.2`, & `1.17.1` for flink using the new dlcnd sub-domain.

### DIFF
--- a/flink.hcl
+++ b/flink.hcl
@@ -38,4 +38,7 @@ sha256sums = {
   "https://archive.apache.org/dist/flink/flink-1.15.3/flink-1.15.3-bin-scala_2.12.tgz": "ec11267fdecf91f70717fd060d39b44e4108bb43c42de76d8c3b7542ddf07d7f",
   "https://archive.apache.org/dist/flink/flink-1.16.0/flink-1.16.0-bin-scala_2.12.tgz": "63ba08dd23d2979dab2cd3c192a69f548040b5411479a7ef430517c8e4a8009b",
   "https://archive.apache.org/dist/flink/flink-1.16.1/flink-1.16.1-bin-scala_2.12.tgz": "30c0b96cbf73fbe834fa5bfb8b187d463ebfa955f5d43d7aa3198d87eb2c7a65",
+  "https://dlcdn.apache.org/flink/flink-1.15.4/flink-1.15.4-bin-scala_2.12.tgz": "a0046fd512ddee23a6d706febd0f940b948ccac10c815ee5fb651a0a0e2d3b8c",
+  "https://dlcdn.apache.org/flink/flink-1.16.2/flink-1.16.2-bin-scala_2.12.tgz": "5945846f4a209568f2391eaf45f91191d0c0c4aa5d980e199d42bb6d02187206",
+  "https://dlcdn.apache.org/flink/flink-1.17.1/flink-1.17.1-bin-scala_2.12.tgz": "1e95434b7c9d8b667548834051e77d9678bd8bc142af4488f3204260fe30c723",
 }

--- a/flink.hcl
+++ b/flink.hcl
@@ -13,12 +13,24 @@ version "1.15.3" {
   source = "https://archive.apache.org/dist/flink/flink-1.15.3/flink-1.15.3-bin-scala_2.12.tgz"
 }
 
+version "1.15.4" {
+  source = "https://dlcdn.apache.org/flink/flink-1.15.4/flink-1.15.4-bin-scala_2.12.tgz"
+}
+
 version "1.16.0" {
   source = "https://archive.apache.org/dist/flink/flink-1.16.0/flink-1.16.0-bin-scala_2.12.tgz"
 }
 
 version "1.16.1" {
   source = "https://archive.apache.org/dist/flink/flink-1.16.1/flink-1.16.1-bin-scala_2.12.tgz"
+}
+
+version "1.16.2" {
+  source = "https://dlcdn.apache.org/flink/flink-1.16.2/flink-1.16.2-bin-scala_2.12.tgz"
+}
+
+version "1.17.1" {
+  source = "https://dlcdn.apache.org/flink/flink-1.17.1/flink-1.17.1-bin-scala_2.12.tgz"
 }
 
 sha256sums = {


### PR DESCRIPTION
According to Apache Downloads (https://www.apache.org/dyn/closer.cgi):

> We suggest the following site for your download:
>
> https://dlcdn.apache.org/

It is my understanding that the archive was previously used and kept for historical reasons.