### PR TITLE
Adds version 0.6.2 of the codecov uploader

### DIFF
--- a/codecov.hcl
+++ b/codecov.hcl
@@ -2,7 +2,7 @@ description = "Codecov Report Uploader"
 binaries = ["codecov"]
 test = "codecov --version"
 
-version "0.3.2" {
+version "0.3.2" "0.6.2" {
 }
 
 linux {
@@ -30,4 +30,7 @@ darwin {
 sha256sums = {
   "https://github.com/codecov/uploader/releases/download/v0.3.2/codecov-macos": "ccc032e70958ea3eca9bd15c7fdad5bbacc279c3bab22f227417573356569666",
   "https://github.com/codecov/uploader/releases/download/v0.3.2/codecov-linux": "20f9c9d78483fce977b6cc39e231a734a23bcd36f4d536bb7355222fb88d02bc",
+  "https://github.com/codecov/uploader/releases/download/v0.6.2/codecov-macos": "b29175637f889a02443f60cfa87aa375e01539ec13505b0d2a53597c9ab04135",
+  "https://github.com/codecov/uploader/releases/download/v0.6.2/codecov-linux": "6e2f9d1f9f03dcc42fac16711e0d11c0475aff20c6d0ef5ea90dfdfa0af0103f",
+
 }


### PR DESCRIPTION
Adds version 0.6.2 of the codecov uploader since codecov support indicated we're running into bugs since we're using an old uploader version in this ticket: https://codecoventerprise.codecov.io/hc/en-us/requests/102089

<img width="892" alt="image" src="https://github.com/cashapp/hermit-packages/assets/1313566/84345233-4da8-487c-a69c-d164ce3cc0c0">

where CodeCov is counting comments as part of it's code quality inspections