### PR TITLE
fix: Add default vars for overrides in bitwarden cli's

### DIFF
--- a/bitwarden-cli.hcl
+++ b/bitwarden-cli.hcl
@@ -9,6 +9,10 @@ platform "darwin" {
   }
 }
 
+vars = {
+  "os_": "${os}",
+}
+
 version "2023.7.0" {
   auto-version {
     github-release = "bitwarden/clients"

--- a/bitwarden-cli.hcl
+++ b/bitwarden-cli.hcl
@@ -3,14 +3,14 @@ binaries = ["bw"]
 test = "bw --version"
 source = "https://github.com/bitwarden/clients/releases/download/cli-v${version}/bw-${os_}-${version}.zip"
 
+vars = {
+  "os_": "${os}",
+}
+
 platform "darwin" {
   vars = {
     "os_": "macos",
   }
-}
-
-vars = {
-  "os_": "${os}",
 }
 
 version "2023.7.0" {

--- a/bitwarden-secrets-cli.hcl
+++ b/bitwarden-secrets-cli.hcl
@@ -27,6 +27,11 @@ platform "windows" {
   }
 }
 
+vars = {
+  "arch_": "${arch}",
+  "os_": "${os}",
+}
+
 version "0.3.0" {
   auto-version {
     github-release = "bitwarden/sdk"

--- a/bitwarden-secrets-cli.hcl
+++ b/bitwarden-secrets-cli.hcl
@@ -3,6 +3,11 @@ binaries = ["bws"]
 test = "bws --version"
 source = "https://github.com/bitwarden/sdk/releases/download/bws-v${version}/bws-${arch_}-${os_}-${version}.zip"
 
+vars = {
+  "arch_": "${arch}",
+  "os_": "${os}",
+}
+
 platform "amd64" {
   vars = {
     "arch_": "x86_64",
@@ -25,11 +30,6 @@ platform "windows" {
   vars = {
     "os_": "pc-windows-msvc",
   }
-}
-
-vars = {
-  "arch_": "${arch}",
-  "os_": "${os}",
 }
 
 version "0.3.0" {


### PR DESCRIPTION
I'm uncertain if this is correct, I noticed a bug where certain os's wouldn't work because the `os_` var didn't resolve. This appears to default the values if there is no override present.