### PR TITLE
Add envtpl and k8split

### DIFF
--- a/envtpl.hcl
+++ b/envtpl.hcl
@@ -1,0 +1,11 @@
+description = "Render Go templates on the command line with shell environment variables"
+binaries = ["envtpl"]
+source = "https://github.com/cashapp/hermit-build/releases/download/go-tools/envtpl-${os}-${arch}.bz2"
+
+on unpack {
+  rename { from = "${root}/envtpl-${os}-${arch}" to = "${root}/envtpl" }
+}
+
+channel "latest" {
+  update = "24h"
+}

--- a/k8split.hcl
+++ b/k8split.hcl
@@ -1,0 +1,11 @@
+description = "A CLI for splitting multidocument yaml files into discrete documents"
+binaries = ["k8split"]
+source = "https://github.com/cashapp/hermit-build/releases/download/go-tools/k8split-${os}-${arch}.bz2"
+
+on unpack {
+  rename { from = "${root}/k8split-${os}-${arch}" to = "${root}/k8split" }
+}
+
+channel "latest" {
+  update = "24h"
+}


### PR DESCRIPTION
Package `envtpl` and `k8split`, fetching from hermit-build (see https://github.com/cashapp/hermit-build/pull/14)