### PR TITLE
[WIP: Do Not Review]: Add Ansible and Ansible-Playbook to CashApp Hermit

### DIFF
--- a/ansible.hcl
+++ b/ansible.hcl
@@ -1,0 +1,13 @@
+description = "Ansible is a tool for creating playbooks that define and manage the state of remote resources."
+source = "https://github.com/ansible/ansible/archive/${version}.tar.gz"
+binaries = ["bin/ansible", "bin/ansible-playbook"]
+test = "ansible-playbook --version"
+
+version "v2.16.1" {
+}
+
+version "v2.10.17" "v2.11.12" "v2.12.10" "v2.13.13" "v2.14.11" "v2.15.7" "v2.16.1" "devel" {
+  auto-version {
+    github-release = "ansible/ansible"
+  }
+}


### PR DESCRIPTION
## Why

We're using Hermit for a pipeline hoping to use Packer and Ansible in tandem

## Test (Needs Help):

Currently, I need some advice on what to define as the `ansible` and `ansible-playbook` "Binary". So far, `bin/ansible`, `ansible`, and `lib/ansible` have not worked yet

Example failed test output:
```
hermit-packages🐚 ➜  hermit-packages git:(add-ansible) ✗ hermit test ansible --trace
info:validate: Validating ansible@v2.16
trace: HEAD https://github.com/ansible/ansible/archive/v2.16.1.tar.gz
trace: HEAD https://codeload.github.com/ansible/ansible/tar.gz/refs/tags/v2.16.1
trace: HEAD https://github.com/ansible/ansible/archive/v2.16.1.tar.gz
trace: HEAD https://codeload.github.com/ansible/ansible/tar.gz/refs/tags/v2.16.1
trace: HEAD https://github.com/ansible/ansible/archive/v2.16.1.tar.gz
trace: HEAD https://codeload.github.com/ansible/ansible/tar.gz/refs/tags/v2.16.1
fatal: app/test_cmd.go:36: env.go:488: state/state.go:308: state/state.go:352: manifest/resolver.go:133: ansible-v2.16.1: failed to find binaries "/Users/wveck/Library/Caches/hermit/pkg/ansible-v2.16.1/bin"
```