### PR TITLE
fix(errtrace): Fix auto-version section

### DIFF
--- a/errtrace.hcl
+++ b/errtrace.hcl
@@ -12,7 +12,7 @@ on "unpack" {
 
 version "0.2.0" {
   auto-version {
-    github-release = "dmarkham/enumer"
+    github-release = "bracesdev/errtrace"
   }
 }
 


### PR DESCRIPTION
The auto-version for errtrace references another project
instead of itself.
