### PR TITLE
Add a manifest for nsc client for namespace.so

### DIFF
--- a/nsc.hcl
+++ b/nsc.hcl
@@ -2,14 +2,7 @@ description = "a client for Namespace's cloud"
 homepage = "https://github.com/namespacelabs/foundation"
 binaries = ["nsc"]
 test = "nsc -h"
-
-platform "amd64" {
-  source = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${os}_${arch}.tar.gz"
-}
-
-platform "arm64" {
-  source = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${os}_${arch}.tar.gz"
-}
+source = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${os}_${arch}.tar.gz"
 
 version "0.0.322"  {
   auto-version {

--- a/nsc.hcl
+++ b/nsc.hcl
@@ -1,0 +1,18 @@
+description = "a client for Namespace's cloud"
+homepage = "https://github.com/namespacelabs/foundation"
+binaries = ["nsc"]
+test = "nsc -h"
+
+platform "amd64" {
+  source = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${os}_${arch}.tar.gz"
+}
+
+platform "arm64" {
+  source = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${os}_${arch}.tar.gz"
+}
+
+version "0.0.322"  {
+  auto-version {
+    github-release = "namespacelabs/foundation"
+  }
+}


### PR DESCRIPTION
This adds a manifest for `nsc` which is the client for Namespace.so which provides hosted GitHub Actions and Buildkite Workers. 

For more details see https://namespace.so/docs/getting-started/installation

@nichtverstehen any interest in referencing Hermit in the install docs?