### PR TITLE
Install docker-credential-nsc in the nsc manifest

### DIFF
--- a/nsc.hcl
+++ b/nsc.hcl
@@ -1,6 +1,6 @@
-description = "a client for Namespace's cloud"
+description = "A client for Namespace's cloud"
 homepage = "https://github.com/namespacelabs/foundation"
-binaries = ["nsc"]
+binaries = ["nsc", "docker-credential-nsc"]
 test = "nsc -h"
 source = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${os}_${arch}.tar.gz"
 


### PR DESCRIPTION
I missed that there was an additional binary to be installed next to the `nsc` binary in https://github.com/cashapp/hermit-packages/pull/429. 

This adds it! 