### PR TITLE
Add a manifest for ffprobe (part of ffmpeg)

### DIFF
--- a/ffprobe.hcl
+++ b/ffprobe.hcl
@@ -18,7 +18,7 @@ platform "amd64" {
   }
 }
 
-version "5.0" "5.0.1" "6.0" {
+version "6.0" {
   auto-version {
     github-release = "eugeneware/ffmpeg-static"
     version-pattern = "b(.*)"

--- a/ffprobe.hcl
+++ b/ffprobe.hcl
@@ -1,0 +1,27 @@
+description = "A multimedia stream analyzer tool used to obtain detailed information about audio and video files (part of the ffmpeg project)"
+binaries = ["ffprobe"]
+vars = {
+  "arch_": "${arch}",
+}
+source = "https://github.com/eugeneware/ffmpeg-static/releases/download/b${version}/ffprobe-${os}-${arch_}.gz"
+
+on "unpack" {
+  rename {
+    from = "${root}/ffprobe-${os}-${arch_}"
+    to = "${root}/ffprobe"
+  }
+}
+
+platform "amd64" {
+  vars = {
+    "arch_": "x64",
+  }
+}
+
+version "5.0" "5.0.1" "6.0" {
+  auto-version {
+    github-release = "eugeneware/ffmpeg-static"
+    version-pattern = "b(.*)"
+    ignore-invalid-versions = true
+  }
+}


### PR DESCRIPTION
ffprobe is a companion binary to ffmpeg and they are released together. I considered whether to add this to the ffmpeg manifest, but they end up quite large statically linked binaries and it's nice to be able to choose which you install.