### PR TITLE
Add actionlint package

### DIFF
--- a/actionlint.hcl
+++ b/actionlint.hcl
@@ -1,0 +1,10 @@
+description = "Static checker for GitHub Actions workflow files "
+test = "actionlint --version"
+binaries = ["actionlint"]
+
+version "1.6.26" {
+  source = "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_${os}_${arch}.tar.gz"
+  auto-version {
+    github-release = "rhysd/actionlint/"
+  }
+}


### PR DESCRIPTION
Add actionlint package, because waiting for GitHub workflow runs is too cumbersome an the hermit package `action-validator` didn't work.
cc @camh- 