### PR TITLE
Add mysql-client and mysqladmin 8.0.36 versions

### DIFF
--- a/mysql-client.hcl
+++ b/mysql-client.hcl
@@ -29,10 +29,34 @@ version "8.0.27" {
   }
 }
 
+version "8.0.36" {
+  platform "darwin" "amd64" {
+    source = "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-${version}-macos14-x86_64.tar.gz"
+  }
+
+  platform "darwin" "arm64" {
+    source = "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-${version}-macos14-arm64.tar.gz"
+  }
+
+  platform "linux" "amd64" {
+    source = "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-${version}-ubuntu_multirelease-amd64.tar.gz"
+
+    on "unpack" {
+      run {
+        cmd = "/bin/bash"
+        args = ["-c", "mkdir bin; if grep -q 22.04 /etc/lsb-release; then mv mysql-22.04 bin/mysql; else mv mysql-20.04 bin/mysql; fi"]
+      }
+    }
+  }
+}
+
 sha256sums = {
   "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.21-linux-glibc2.17-x86_64-minimal.tar.xz": "e6503f2ca665dbd4524a0109fa15969453f02b69c20f42d3fe8ba0d0b0ca1a1f",
   "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.21-macos10.15-x86_64.tar.gz": "ddfb29e700b8351a8d0dd300b8ef390ef7e0caeb5256268047a58f1f0338bdcf",
   "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-client-core_8.0.27-1ubuntu20.04_amd64.deb": "88583c400085e381673e8f026948e94a1abe3b931d2074978b5dfeff16e2557a",
   "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-8.0.27-macos11-x86_64.tar.gz": "ba3aeadb76348fdf6f0684abe66cf753d1f08312893c249ac36db1a4ed38258d",
   "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-8.0.27-macos11-arm64.tar.gz": "8083c20ef46c153bc13e6d48611b1214917d53f644629e6ef35768fd001b05d0",
+  "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-8.0.36-ubuntu_multirelease-amd64.tar.gz": "573ca75c679dfbe88e216f6446dec5fbe2c2297dc34c38ff127fb6c5771f7e8c",
+  "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-8.0.36-macos14-x86_64.tar.gz": "fe33fc66c716621171b35d77e7c830d62638e190128e22b311cd29aaccc54cef",
+  "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysql-8.0.36-macos14-arm64.tar.gz": "a47b1cea57dc7be822c0ffad8e58ad87952e2984635ecf3f15234e48c51c35bc",
 }

--- a/mysqladmin.hcl
+++ b/mysqladmin.hcl
@@ -19,8 +19,32 @@ version "8.0.28" {
   }
 }
 
+version "8.0.36" {
+  platform "darwin" "amd64" {
+    source = "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-${version}-macos14-x86_64.tar.gz"
+  }
+
+  platform "darwin" "arm64" {
+    source = "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-${version}-macos14-arm64.tar.gz"
+  }
+
+  platform "linux" "amd64" {
+    source = "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-${version}-ubuntu_multirelease-amd64.tar.gz"
+
+    on "unpack" {
+      run {
+        cmd = "/bin/bash"
+        args = ["-c", "mkdir bin; if grep -q 22.04 /etc/lsb-release; then mv mysqladmin-22.04 bin/mysqladmin; else mv mysqladmin-20.04 bin/mysqladmin; fi"]
+      }
+    }
+  }
+}
+
 sha256sums = {
   "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-client_8.0.28-1ubuntu20.04_amd64.deb": "b29ea10ce1d6dd7188280f7491d118bc65f552ef3418db96cbda7d74b26cfb40",
   "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-8.0.28-macos11-x86_64.tar.gz": "a58b23fa1b0a5778f1f2cab3f98e110d6bb542c455c6e6c0845a33eb85865d4f",
   "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-8.0.28-macos11-arm64.tar.gz": "5d66deb1fcf0b750cf1040387dc43938016ed53bcab38baa2cfc287e648f5939",
+  "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-8.0.36-ubuntu_multirelease-amd64.tar.gz": "63addc61a5f48824d53af8c777af59f0b26dd9b08f7e57fc34133209f6f2caaa",
+  "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-8.0.36-macos14-x86_64.tar.gz": "d19bc9ea22ff847f9a6b364c7008d1c204d7e9f94e7b1fc2fcf949db753f3a20",
+  "https://github.com/cashapp/hermit-build/releases/download/mysql-client/mysqladmin-8.0.36-macos14-arm64.tar.gz": "7314678a47eee4d8f6292cbffbd75558c97472cc41a84d19ee32d4e42c41021e",
 }


### PR DESCRIPTION
These versions use a multirelease tarball for ubuntu, and select the appropriate binary inside the tarball on unpack. This is needed to work around libssl dynamic library dependencies that differ on the two versions of Ubuntu.