### PR TITLE
Podman gvproxy mamba

### DIFF
--- a/gvproxy.hcl
+++ b/gvproxy.hcl
@@ -1,0 +1,50 @@
+description = "gvproxy is a new network stack based on gVisor."
+binaries = ["gvproxy"]
+test = "gvproxy --version"
+
+version "0.7.3" {
+  auto-version {
+    github-release = "containers/gvisor-tap-vsock"
+    version-pattern = "v(.*)"
+  }
+}
+
+platform "linux" {
+  source = "https://github.com/containers/gvisor-tap-vsock/releases/download/v${version}/gvproxy-linux-${arch}"
+
+  on "unpack" {
+    rename {
+      from = "${root}/gvproxy-linux-amd64"
+      to = "${root}/gvproxy"
+    }
+  }
+}
+
+platform "darwin" {
+  source = "https://github.com/containers/gvisor-tap-vsock/releases/download/v${version}/gvproxy-darwin"
+
+  on "unpack" {
+    rename {
+      from = "${root}/gvproxy-darwin"
+      to = "${root}/gvproxy"
+    }
+  }
+}
+
+platform "windows" {
+  source = "https://github.com/containers/gvisor-tap-vsock/releases/download/v${version}/gvproxy-windows.exe"
+
+  on "unpack" {
+    rename {
+      from = "${root}/gvproxy-windows.exe"
+      to = "${root}/gvproxy.exe"
+    }
+  }
+}
+
+sha256sums = {
+    "https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-linux-amd64": "a0532048e2310c1f4b3c438a502fee651b5c3dc4360ff66a29204047145b3d63",
+    "https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-linux-arm64": "996c526e4291926129c5a76f8e673c01bde98c1be51457ded3e419605b54c6f8",
+    "https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-darwin": "a69c0d00d3ae3e295aa5b45ab664ef8c3e2094937d9d63af743c8440d22ead21",
+    "https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-windows.exe": "bd2687b203a2f0dc27169c0c017b64d1408a89e8cd1e11c115cbb2d93f106086",
+}

--- a/micromamba.hcl
+++ b/micromamba.hcl
@@ -3,8 +3,8 @@ binaries = ["micromamba"]
 test = "micromamba --help"
 env = {
   "MAMBA_ROOT_PREFIX": "${HERMIT_ENV}/.hermit/micromamba",
-  "CONDA_PREFIX": "${MAMBA_ROOT_PREFIX}",
-  "PATH": "${CONDA_PREFIX}/bin:${PATH}",
+  "CONDA_PREFIX": "${HERMIT_ENV}/.hermit/micromamba",
+  "PATH": "${HERMIT_ENV}/.hermit/micromamba/bin:${PATH}",
 }
 
 version "1.5.3-0" "1.5.5-0" "1.5.6-0" {

--- a/micromamba.hcl
+++ b/micromamba.hcl
@@ -2,6 +2,7 @@ description = "Micromamba is a tiny version of the mamba package manager which i
 binaries = ["micromamba"]
 test = "micromamba --help"
 env = {
+  "MAMBA_EXE": "${HERMIT_ENV}/bin/micromamba",
   "MAMBA_ROOT_PREFIX": "${HERMIT_ENV}/.hermit/micromamba",
   "CONDA_PREFIX": "${HERMIT_ENV}/.hermit/micromamba",
   "PATH": "${HERMIT_ENV}/.hermit/micromamba/bin:${PATH}",

--- a/podman.hcl
+++ b/podman.hcl
@@ -2,6 +2,7 @@ description = "A tool for managing OCI containers and pods."
 sha256-source = "https://github.com/containers/podman/releases/download/v${version}/shasums"
 binaries = ["podman"]
 source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz"
+requires = [ "gvproxy" ]
 
 platform "darwin" {
   source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin_${arch}.zip"
@@ -64,11 +65,25 @@ version "4.4.1" "4.4.4" "4.5.0" "4.5.1" "4.6.0" "4.6.1" "4.6.2" "4.7.0" "4.7.1" 
 
   platform "linux" {
     source = "https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz"
+    env = {
+      "CONTAINERS_CONF": "${HERMIT_ENV}/.hermit/podman/containers.conf",
+      "CONTAINER_HOST": "unix://${HOME}/.local/share/containers/podman/machine/qemu/podman.sock",
+    }
 
     on "unpack" {
       rename {
         from = "${root}/bin/podman-remote-static-linux_${arch}"
         to = "${root}/podman"
+      }
+    }
+
+    on "install" {
+      mkdir {
+        dir = "${HERMIT_ENV}/.hermit/podman"
+      }
+      run {
+        cmd = "/bin/bash"
+        args = ["-c", "echo \"[engine]\n  helper_binaries_dir = [\n    \"'\"'\"${HERMIT_ENV}/bin\"'\"'\"\n]\n\" > \"${HERMIT_ENV}/.hermit/podman/containers.conf\""]
       }
     }
   }


### PR DESCRIPTION
- Update to podman to use gvproxy
- new gvproxy package
- update to micromamba to set MAMBA_EXE environment variable (needed for proper activation)
