### PR TITLE
Fix arch syntax in bitwarden-secrets-cli package

### DIFF
--- a/bitwarden-secrets-cli.hcl
+++ b/bitwarden-secrets-cli.hcl
@@ -2,16 +2,26 @@ description = "The Bitwarden secrets command-line interface (CLI) is used for ma
 binaries = ["bws"]
 test = "bws --version"
 source = "https://github.com/bitwarden/sdk/releases/download/bws-v${version}/bws-${arch_}-${os_}-${version}.zip"
+vars = {
+  "arch_": "${arch}",
+  "os_": "${os}",
+}
 
 platform "amd64" {
   vars = {
-    "arch_": "x86_64",
+    "arch_": "${xarch}",
   }
 }
 
 platform "darwin" {
   vars = {
     "os_": "apple-darwin",
+  }
+}
+
+platform "darwin" "arm64" {
+  vars = {
+    "arch_": "aarch64",
   }
 }
 
@@ -27,7 +37,7 @@ platform "windows" {
   }
 }
 
-version "0.3.0" {
+version "0.3.0" "0.4.0" {
   auto-version {
     github-release = "bitwarden/sdk"
     ignore-invalid-versions = true
@@ -38,5 +48,8 @@ version "0.3.0" {
 sha256sums = {
   "https://github.com/bitwarden/sdk/releases/download/bws-v0.3.0/bws-x86_64-unknown-linux-gnu-0.3.0.zip": "8a2126e6ae316264a7e2fb1b9d4b4c72edcd7b7951d51b8174f3d6c3b106995f",
   "https://github.com/bitwarden/sdk/releases/download/bws-v0.3.0/bws-x86_64-apple-darwin-0.3.0.zip": "a4d4324a6799ce29f5b71a753e444376baa08a4c9dc1b3c2d237215294aba6ac",
-  "https://github.com/bitwarden/sdk/releases/download/bws-v0.3.0/bws-x86_64-pc-windows-msvc-0.3.0.zip": "3260b9bad8fd90e2131b8652df1bcfd25c82b89ebf59b3aaf0b481221ac5849c",
+  "https://github.com/bitwarden/sdk/releases/download/bws-v0.3.0/bws-aarch64-apple-darwin-0.3.0.zip": "6b8f6bdbd6a4cad6a0b5c08fdc2984895f4a605fdaac7a6ea812a7f08d9dc4e0",
+  "https://github.com/bitwarden/sdk/releases/download/bws-v0.4.0/bws-x86_64-unknown-linux-gnu-0.4.0.zip": "3b9514050e680c0bb2497f8bc6d1cd90e6a00c81db69867af251fab6c142814d",
+  "https://github.com/bitwarden/sdk/releases/download/bws-v0.4.0/bws-x86_64-apple-darwin-0.4.0.zip": "db5fa8fccbfc3427ab30ec71ac2236fed812c464a3475f21353e1a3a3e41802f",
+  "https://github.com/bitwarden/sdk/releases/download/bws-v0.4.0/bws-aarch64-apple-darwin-0.4.0.zip": "a151439b32761451b646afb88638c2b5ca593cea28ffaef422e27f4e982e0852",
 }


### PR DESCRIPTION
The `bitwarden-secrets-cli` package was giving the following warnings:

```text
warn: invalid manifest reference bitwarden-secrets-cli-0.3.0 in bitwarden-secrets-cli.hcl: unknown variable $arch_
warn: invalid manifest reference bitwarden-secrets-cli@latest in bitwarden-secrets-cli.hcl: unknown variable $arch_
warn: invalid manifest reference bitwarden-secrets-cli@0 in bitwarden-secrets-cli.hcl: unknown variable $arch_
warn: invalid manifest reference bitwarden-secrets-cli@0.3 in bitwarden-secrets-cli.hcl: unknown variable $arch_
```

This PR fixes the error and updates the manifest with the latest version of `bws`.

`hermit manifest auto-version` dropped the windows versions for some reason, I'm not sure why that happened.