### PR TITLE
Gradle 8.8

### DIFF
--- a/gradle.hcl
+++ b/gradle.hcl
@@ -6,7 +6,7 @@ binaries = ["bin/gradle"]
 repository = "https://github.com/gradle/gradle"
 
 version "6.7" "6.8.3" "7.0" "7.1" "7.2" "7.3.2" "7.4.2" "7.5" "7.6" "7.6.1" "7.6.2"
-        "7.6.3" "8.0-rc-2" "8.0.1" "8.0.2" "8.1.1" "8.2" "8.2.1" "8.3" "8.4" "8.5" "8.6" "8.7" {
+        "7.6.3" "8.0-rc-2" "8.0.1" "8.0.2" "8.1.1" "8.2" "8.2.1" "8.3" "8.4" "8.5" "8.6" "8.7" "8.8" {
   auto-version {
     github-release = "gradle/gradle"
   }
@@ -35,6 +35,7 @@ sha256sums = {
   "https://services.gradle.org/distributions/gradle-8.5-bin.zip": "9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026",
   "https://services.gradle.org/distributions/gradle-8.6-bin.zip": "9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c",
   "https://services.gradle.org/distributions/gradle-8.7-bin.zip": "544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d",
+  "https://services.gradle.org/distributions/gradle-8.8-bin.zip": "a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612",
   "https://services.gradle.org/distributions/gradle-7.6.2-bin.zip": "a01b6587e15fe7ed120a0ee299c25982a1eee045abd6a9dd5e216b2f628ef9ac",
   "https://services.gradle.org/distributions/gradle-7.6.3-bin.zip": "740c2e472ee4326c33bf75a5c9f5cd1e69ecf3f9b580f6e236c86d1f3d98cfac",
 }


### PR DESCRIPTION
https://docs.gradle.org/8.8/release-notes.html

[checksum](https://gradle.org/release-checksums/) matches locally:

``` bash
$ curl -sSL https://services.gradle.org/distributions/gradle-8.8-bin.zip | sha256sum
a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
```