### PR TITLE
Add abhinav/stitchmd

### DIFF
--- a/stitchmd.hcl
+++ b/stitchmd.hcl
@@ -1,0 +1,19 @@
+description = "Stitches multiple Markdown files together."
+homepage = "https://github.com/abhinav/stitchmd"
+binaries = ["stitchmd"]
+test = "stitchmd --version"
+sha256-source = "https://github.com/abhinav/stitchmd/releases/download/v${version}/checksums.txt"
+
+version "0.9.0" {
+  source = "https://github.com/abhinav/stitchmd/releases/download/v${version}/stitchmd-${os}-${arch}.tar.gz"
+
+  auto-version {
+    github-release = "abhinav/stitchmd"
+  }
+}
+
+sha256sums = {
+  "https://github.com/abhinav/stitchmd/releases/download/v0.9.0/stitchmd-linux-amd64.tar.gz": "0fca7cca22f22b2c29d2b2399d6dca7fc8e634ae95ee89226bb99dd7d916bd0d",
+  "https://github.com/abhinav/stitchmd/releases/download/v0.9.0/stitchmd-darwin-amd64.tar.gz": "e4a4053fe1c8addec90fc7dc3580d76130940946ae7f3377c9a08503e07b9fae",
+  "https://github.com/abhinav/stitchmd/releases/download/v0.9.0/stitchmd-darwin-arm64.tar.gz": "d12bddffd22c4636136240d7352c98ce4f26e26c368445f8bd2cba33aa38daaa",
+}


### PR DESCRIPTION
[stitchmd](https://github.com/abhinav/stitchmd) is a tool I wrote
to allow writing large Markdown files comprised of many smaller files.
I use it in most of my project READMEs and it's also used by the
[Uber Go Style Guide](https://github.com/uber-go/guide).

This adds stitchmd to hermit-packages.
