### PR TITLE
Update sqlite.hcl to version 3.46.1

### DIFF
--- a/sqlite.hcl
+++ b/sqlite.hcl
@@ -3,15 +3,16 @@ binaries = ["*"]
 strip = 1
 
 platform "linux" "amd64" {
-  source = "https://www.sqlite.org/${year}/sqlite-tools-linux-x86-${encoded_version}.zip"
+  source = "https://www.sqlite.org/${year}/sqlite-tools-linux-${cpu}-${encoded_version}.zip"
 }
 
 platform "darwin" {
-  source = "https://www.sqlite.org/${year}/sqlite-tools-osx-x86-${encoded_version}.zip"
+  source = "https://www.sqlite.org/${year}/sqlite-tools-osx-${cpu}-${encoded_version}.zip"
 }
 
 version "3.39.2" {
   vars = {
+    "cpu": "x86",
     "encoded_version": "3390200",
     "year": "2022",
   }
@@ -19,6 +20,7 @@ version "3.39.2" {
 
 version "3.40.0" {
   vars = {
+    "cpu": "x86",
     "encoded_version": "3400000",
     "year": "2022",
   }
@@ -26,8 +28,17 @@ version "3.40.0" {
 
 version "3.42.0" {
   vars = {
+    "cpu": "x86",
     "encoded_version": "3420000",
     "year": "2023",
+  }
+}
+
+version "3.46.1" {
+  vars = {
+    "cpu": "x64",
+    "encoded_version": "3460100",
+    "year": "2024",
   }
 }
 
@@ -38,4 +49,6 @@ sha256sums = {
   "https://www.sqlite.org/2022/sqlite-tools-osx-x86-3400000.zip": "13fd9612729736d9f3a4368105357ec9e0903f83c8534556596d10f935f2ca8c",
   "https://www.sqlite.org/2023/sqlite-tools-linux-x86-3420000.zip": "694f7c2e061375e7ca3cca77e44d31ef1b53769d6a2b64a9be2a5744603b3342",
   "https://www.sqlite.org/2023/sqlite-tools-osx-x86-3420000.zip": "0096425ca008fe365b293e8de900bd4946be2515e9e08885f07c18b04c8f7b4d",
+  "https://sqlite.org/2024/sqlite-tools-linux-x64-3460100.zip": "6a74862884295d625ab015abdcb20cdf29e7cbc3fcfd0c2b3966059bfac21b6c",
+  "https://sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip": "556a1c132484c762abcc6ceca40649e1d08bfb17a52f61ec27c300ca50738d1e",
 }


### PR DESCRIPTION
Had to introduce a `cpu` variable cause it looks like they switched to `x64`