### PR TITLE
fix: update path prefix for sqlite binaries

### DIFF
--- a/sqlite.hcl
+++ b/sqlite.hcl
@@ -1,6 +1,5 @@
 description = "SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine."
 binaries = ["*"]
-strip = 1
 
 platform "linux" "amd64" {
   source = "https://www.sqlite.org/${year}/sqlite-tools-linux-${cpu}-${encoded_version}.zip"
@@ -11,6 +10,7 @@ platform "darwin" {
 }
 
 version "3.39.2" {
+  strip = 1
   vars = {
     "cpu": "x86",
     "encoded_version": "3390200",
@@ -19,6 +19,7 @@ version "3.39.2" {
 }
 
 version "3.40.0" {
+  strip = 1
   vars = {
     "cpu": "x86",
     "encoded_version": "3400000",
@@ -27,6 +28,7 @@ version "3.40.0" {
 }
 
 version "3.42.0" {
+  strip = 1
   vars = {
     "cpu": "x86",
     "encoded_version": "3420000",
@@ -35,6 +37,7 @@ version "3.42.0" {
 }
 
 version "3.46.1" {
+  strip = 0
   vars = {
     "cpu": "x64",
     "encoded_version": "3460100",


### PR DESCRIPTION
In 3.46.1 version of `sqlite` packaging no longer stores the binaries under a directory, so we get the following error

### Error
```yaml
failed to find binaries "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1/*"
```

#### Detailed error log: `hermit install sqlite-3.46.1 --trace`
```yaml
info:sqlite-3.46.1:install: Installing sqlite-3.46.1
debug:sqlite-3.46.1:install: From https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip
debug:sqlite-3.46.1:install: To /Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1
trace:sqlite-3.46.1: timeout for acquiring the lock is 30s
trace:sqlite-3.46.1: cachePath /Users/redacted/Library/Caches/hermit/cache/2d/2d6fbcc91d554ac9800d94cdc687014c3b885b717fad554c4f0161c069ea918c-sqlite-tools-osx-x64-3460100.zip checksum  url https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip

trace: GET https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip
debug:sqlite-3.46.1:download: Downloading https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip
trace:sqlite-3.46.1: Download https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip (1.049890792s elapsed)
debug:sqlite-3.46.1:unpack: Extracting /Users/redacted/Library/Caches/hermit/cache/2d/2d6fbcc91d554ac9800d94cdc687014c3b885b717fad554c4f0161c069ea918c-sqlite-tools-osx-x64-3460100.zip to /Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1
trace:sqlite-3.46.1:unpack:   sqlite3
trace:sqlite-3.46.1:unpack:   sqldiff
trace:sqlite-3.46.1:unpack:   sqlite3_analyzer
trace:sqlite-3.46.1:unpack: mv "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1-3074874548" "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1"
trace:sqlite-3.46.1:unpack: chmod a-w "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1"
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ 3/3    100.0%

fatal: app/install_cmd.go:97: env.go:563: env.go:648: state/state.go:308: state/state.go:357: manifest/resolver.go:133: sqlite-3.46.1: failed to find binaries "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1/*"
```


#### Detailed fixed log: `hermit install sqlite-3.46.1 --trace`
```yaml
info:sqlite-3.46.1:install: Installing sqlite-3.46.1
debug:sqlite-3.46.1:install: From https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip
debug:sqlite-3.46.1:install: To /Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1
trace:sqlite-3.46.1: timeout for acquiring the lock is 30s
trace:sqlite-3.46.1: cachePath /Users/redacted/Library/Caches/hermit/cache/2d/2d6fbcc91d554ac9800d94cdc687014c3b885b717fad554c4f0161c069ea918c-sqlite-tools-osx-x64-3460100.zip checksum  url https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip

trace: GET https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip
debug:sqlite-3.46.1:download: Downloading https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip
trace:sqlite-3.46.1: Download https://www.sqlite.org/2024/sqlite-tools-osx-x64-3460100.zip (1.097068041s elapsed)
debug:sqlite-3.46.1:unpack: Extracting /Users/redacted/Library/Caches/hermit/cache/2d/2d6fbcc91d554ac9800d94cdc687014c3b885b717fad554c4f0161c069ea918c-sqlite-tools-osx-x64-3460100.zip to /Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1
trace:sqlite-3.46.1:unpack:   sqlite3
trace:sqlite-3.46.1:unpack:   sqldiff
trace:sqlite-3.46.1:unpack:   sqlite3_analyzer
trace:sqlite-3.46.1:unpack: mv "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1-3388432684" "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1"
trace:sqlite-3.46.1:unpack: chmod a-w "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1"
trace:sqlite-3.46.1:unpack: chmod a-w "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1/sqldiff"
trace:sqlite-3.46.1:unpack: chmod a-w "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1/sqlite3"
trace:sqlite-3.46.1:unpack: chmod a-w "/Users/redacted/Library/Caches/hermit/pkg/sqlite-3.46.1/sqlite3_analyzer"
debug:sqlite-3.46.1:link: Linking binaries for sqlite-3.46.1
debug:sqlite-3.46.1:link: ln -s "hermit" "/Users/redacted/Development/hermit-test/bin/.sqlite-3.46.1.pkg"
debug:sqlite-3.46.1:link: ln -s ".sqlite-3.46.1.pkg" "/Users/redacted/Development/hermit-test/bin/sqldiff"
debug:sqlite-3.46.1:link: ln -s ".sqlite-3.46.1.pkg" "/Users/redacted/Development/hermit-test/bin/sqlite3"
debug:sqlite-3.46.1:link: ln -s ".sqlite-3.46.1.pkg" "/Users/redacted/Development/hermit-test/bin/sqlite3_analyzer"

```
