### PR TITLE
fix: add awscli 2.17.51

### DIFF
--- a/awscli.hcl
+++ b/awscli.hcl
@@ -13,7 +13,8 @@ linux {
   strip = 1
 }
 
-version "2.0.40" "2.1.26" "2.2.4" "2.4.2" "2.4.4" "2.4.7" "2.5.8" "2.6.4" "2.7.35" "2.13.26" {
+version "2.0.40" "2.1.26" "2.2.4" "2.4.2" "2.4.4" "2.4.7" "2.5.8" "2.6.4" "2.7.35"
+        "2.13.26" "2.17.51" {
   auto-version {
     github-release = "aws/aws-cli"
   }
@@ -40,4 +41,6 @@ sha256sums = {
   "https://awscli.amazonaws.com/AWSCLIV2-2.7.35.pkg": "3673e6491f5f6ce285724197f2903738f7a63d75f968ae23fcb563de9aa95e9b",
   "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.26.zip": "497063433689d2b267046b2a0925c67786226a2c7c1c9682a00aaecae7d491fa",
   "https://awscli.amazonaws.com/AWSCLIV2-2.13.26.pkg": "5d1c6adebe3da7beca37f937b63f942c73d10d03d6aed19934d331555a753bac",
+  "https://awscli.amazonaws.com/AWSCLIV2-2.17.51.pkg": "678459c011edd570219895354ac9c9d1ba1faf49bd98cd3948a51cb25bc2e620",
+  "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.17.51.zip": "507413a75ded890308445aeb8765668c9e34eabafd84af422cff65ced7ef0db1",
 }


### PR DESCRIPTION
awscli's releases tab is empty now for some reason, the auto version doesn't work as expected, added the latest one for now