### PR TITLE
fix(kubebuilder): remove envtest from requires

### DIFF
--- a/kubebuilder.hcl
+++ b/kubebuilder.hcl
@@ -3,7 +3,7 @@ source = "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${ve
 binaries = ["kubebuilder"]
 strip = 2
 test = "kubebuilder version"
-requires = ["envtest"]
+requires = []
 
 version "3.7.0" "3.8.0" "3.9.0" "3.9.1" "3.10.0" "3.11.0" "3.11.1" "3.12.0" "3.13.0"
         "3.14.0" "3.14.1" "3.14.2" "3.15.0" "3.15.1" "4.0.0" "4.1.0" "4.1.1" "4.2.0" {


### PR DESCRIPTION
# Purpose

<img width="858" alt="Screenshot 2024-09-21 at 09 31 19" src="https://github.com/user-attachments/assets/c368e09d-8213-4ef1-b1f3-5fbe3a760174">

When installing `kubebuilder` it looks like there's an issue with an `envtest` dependency, but `kubebuilder` provides a way to manage the resource itself. Since how `envtest` is managed is tied in closely with `kubebuilder` it felt right to manage that resource with `kubebuilder` config rather than in Hermit, but open to handling this a different way!