### PR TITLE
feat:add kubectl argo rollouts cli

### DIFF
--- a/kubectl-argo-rollouts.hcl
+++ b/kubectl-argo-rollouts.hcl
@@ -1,0 +1,27 @@
+description = "Kubectl argo rollouts plugin manages and visualizes rollouts from the command line"
+homepage = "https://argo-rollouts.readthedocs.io/"
+binaries = ["kubectl-argo-rollouts"]
+test = "kubectl-argo-rollouts version"
+source = "https://github.com/argoproj/argo-rollouts/releases/download/v${version}/kubectl-argo-rollouts-${os}-${arch}"
+
+on "unpack" {
+  rename {
+    from = "${root}/kubectl-argo-rollouts-${os}-${arch}"
+    to = "${root}/kubectl-argo-rollouts"
+  }
+}
+
+version "1.7.2" "1.7.1" {
+  auto-version {
+    github-release = "argoproj/argo-rollouts"
+  }
+}
+
+sha256sums = {
+  "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/kubectl-argo-rollouts-darwin-amd64": "cd5c9f39150189c844f7f4b37c149d77e8235edd5d3b48abbf681fc915226d34",
+  "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/kubectl-argo-rollouts-darwin-arm64": "264eaf8360ea005aaaec485ee351214b02a2be87a5e5083419ae93a327ac0b30",
+  "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/kubectl-argo-rollouts-linux-amd64": "af7eac6593bbcac4e219960995e78f6a4b3bb1e6aa47e15a495beb1a4d2da177",
+  "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.1/kubectl-argo-rollouts-darwin-amd64": "173f56252e6d08fe564638a0e28360994430e4ca444713bd5ccfe6392d4a02fa",
+  "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.1/kubectl-argo-rollouts-darwin-arm64": "ff1bd9c502408431d96a053e5db4e2b9561c21060ef6ba66b9ca6aa0a21ed80a",
+  "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.1/kubectl-argo-rollouts-linux-amd64": "b42859a4ead2b02dc1a53a101490f60adc9915b602e033ddc49e78e74a20895b",
+}


### PR DESCRIPTION
## Context
kubectl-argo-rollouts plugin allows you to manage and visualise the argo rollout and can be used as a plugin together with kubectl. 

https://argo-rollouts.readthedocs.io/en/stable/installation/

