### PR TITLE
feat: add yarn

### DIFF
--- a/yarn.hcl
+++ b/yarn.hcl
@@ -1,0 +1,16 @@
+description = "Yarn is a fast, secure, and reliable package manager for JavaScript, designed to manage dependencies efficiently in JavaScript and Node.js projects."
+source = "https://yarnpkg.com/downloads/${version}/yarn-v${version}.tar.gz"
+homepage = "https://yarnpkg.com/"
+repository = "https://github.com/yarnpkg/berry"
+binaries = ["bin/yarn", "bin/yarnpkg"]
+requires = ["node"]
+strip = 1
+test = "yarn --version"
+
+// Yarn v2+, AKA berry, bootstraps itself from either yarn v1 or Corepack, so v2+ releases need not be provided by Hermit.
+version "1.22.22" {
+}
+
+sha256sums = {
+  "https://yarnpkg.com/downloads/1.22.22/yarn-v1.22.22.tar.gz": "88268464199d1611fcf73ce9c0a6c4d44c7d5363682720d8506f6508addf36a0",
+}


### PR DESCRIPTION
Yarn is a bit unique in that it recommends installing via Corepack. To facilitate adding yarn via hermit, we can take the same approach that the official Node.JS Docker image takes, which is to install yarn v1, which can then be used to bootstrap yarn v2 and higher.

Provides an alternative to Corepack for those using Yarn. See also: #253 
Validated against a yarn v3 project using the pnp linker.