### PR TITLE
Add Digests for CiVo and Myks

### DIFF
--- a/civo.hcl
+++ b/civo.hcl
@@ -8,3 +8,9 @@ version "1.1.92" {
     github-release = "civo/cli"
   }
 }
+
+sha256sums = {
+  "https://github.com/civo/cli/releases/download/v1.1.92/civo-1.1.92-linux-amd64.tar.gz": "0bf7bf1741f5c240573127d66810c6af6503dce04587090e4fc6c8132329fe52",
+  "https://github.com/civo/cli/releases/download/v1.1.92/civo-1.1.92-darwin-amd64.tar.gz": "dab3a72d41d6cfaa5f206aec4a584fdaa2b114ac2232be4002af43bf008e27f5",
+  "https://github.com/civo/cli/releases/download/v1.1.92/civo-1.1.92-darwin-arm64.tar.gz": "e41120d54931dc2b300e829fad9cc6fe682f7ecb701081906660c630e68fa0cc",
+}

--- a/myks.hcl
+++ b/myks.hcl
@@ -2,6 +2,7 @@ description = "Myks is a tool and a framework for managing the configuration of 
 binaries = ["myks"]
 source = "https://github.com/mykso/myks/releases/download/v${version}/myks_${version}_${os}_${arch}.tar.gz"
 test = "myks --version"
+strip=0
 
 version "4.2.6" {
   auto-version {

--- a/myks.hcl
+++ b/myks.hcl
@@ -2,10 +2,15 @@ description = "Myks is a tool and a framework for managing the configuration of 
 binaries = ["myks"]
 source = "https://github.com/mykso/myks/releases/download/v${version}/myks_${version}_${os}_${arch}.tar.gz"
 test = "myks --version"
-strip=0
 
 version "4.2.6" {
   auto-version {
     github-release = "mykso/myks"
   }
+}
+
+sha256sums = {
+  "https://github.com/mykso/myks/releases/download/v4.2.6/myks_4.2.6_darwin_amd64.tar.gz": "0ddc00c5eb58add8d2f2d973e37561d2320f38e9c21eb44190375b3b0b6179e9",
+  "https://github.com/mykso/myks/releases/download/v4.2.6/myks_4.2.6_darwin_arm64.tar.gz": "1212f033659e9bcd3383d439f4379b840dc17de56470ab5684705186db0857b6",
+  "https://github.com/mykso/myks/releases/download/v4.2.6/myks_4.2.6_linux_amd64.tar.gz": "f522d4dd654393fdb5352749362a85e89389245319b444d401732637f37701d4",
 }


### PR DESCRIPTION
Sorry, missed this during my initial PR adding myks.

Also: can you tell me how I kick of the auto-versioning? The nightly run didn't fetch all the versions for some reasons.
And when I am running `hermit -d manifest auto-version --update-digests civo.hcl` or `hermit -d manifest auto-version --update-digests myks.hcl` locally they also don't update the files and the output is `debug: Auto-versioning /<path-to-repo>/hermit-packages/<package-name>.hcl`. 

I can't find anything in the documentation to help me here. Help would be greatly appreciated :) 
Thanks