### PR TITLE
fix `op`

### DIFF
--- a/op.hcl
+++ b/op.hcl
@@ -5,7 +5,7 @@ source = "https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_${os}_${arc
 binaries = ["op"]
 test = "op --version"
 
-version "2.30.3" {
+version "2.20.0" "2.21.0" "2.22.0" "2.23.0" "2.24.0" "2.25.0" "2.25.1" "2.26.0" "2.26.1" "2.27.0" "2.28.0" "2.28.0" "2.29.0" "2.30.3" {
   auto-version {
     html {
       url = "https://app-updates.agilebits.com/product_history/CLI2"

--- a/op.hcl
+++ b/op.hcl
@@ -1,54 +1,15 @@
 // CLI Documentation: https://developer.1password.com/docs/cli/
 // CLI Release History: https://app-updates.agilebits.com/product_history/CLI2
 description = "1Password CLI allows you to automate administrative tasks, securely provision secrets across development environments, and use biometrics to authenticate in the terminal."
+source = "https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_${os}_${arch}_v${version}.zip"
 binaries = ["op"]
 test = "op --version"
 
-darwin {
-  source = "https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_apple_universal_v${version}.pkg"
-
-  on "unpack" {
-    // How "${HOME}/usr/local/bin/op" was determined:
-    // 1. curl https://cache.agilebits.com/dist/1P/op2/pkg/v2.18.0/op_apple_universal_v2.18.0.pkg --output op_v2.18.0.pkg
-    // 2. pkgutil --expand op_v2.18.0.pkg op-v2.18.0/
-    // 3. grep install-location op-v2.18.0/op.pkg/PackageInfo
-    rename {
-      from = "${HOME}/usr/local/bin/op"
-      to = "${root}/op"
-    }
-
-    message {
-      text = "It is safe to `rm -r ${HOME}/usr/` if you do not need that directory"
-    }
-  }
-}
-
-linux {
-  source = "https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_linux_${arch}_v${version}.zip"
-}
-
-version "2.18.0" "2.19.0" "2.26.1" "2.27.0" "2.28.0" "2.28.0" "2.29.0" "2.30.3" {
+version "2.30.3" {
   auto-version {
     html {
       url = "https://app-updates.agilebits.com/product_history/CLI2"
       xpath = "//article[*]/h3/text()[normalize-space(.)]"
     }
   }
-}
-
-sha256sums = {
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.18.0/op_linux_amd64_v2.18.0.zip": "2baf610b476727f24c62cc843419f55b157e1a05521a698c1c8b4ed676a766aa",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.18.0/op_apple_universal_v2.18.0.pkg": "19f993c78592e681a05d75aa940e1b126409c854eefdb667a048487d9a5faa98",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.19.0/op_apple_universal_v2.19.0.pkg": "df3543f0b51dc61ceba0b9674028825442c440c3e60ab8917dff396657e048a2",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.26.1/op_apple_universal_v2.26.1.pkg": "34e09118a177dad021e47c306209be7f77a5de5d5d8eabc81cd76947936ca0cf",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.26.1/op_linux_amd64_v2.26.1.zip": "c65c88b5009ebafadf7cc995beae876b545992b14315b267db116aa494c90b81",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.27.0/op_linux_amd64_v2.27.0.zip": "e076905292bba0d6e459353f89fd1d29b626f37e610ee56299bcf8c9201e0405",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.27.0/op_apple_universal_v2.27.0.pkg": "7d4c22109c67e0976c56205053639daf0f85a1ca749e01ff4667e65b652ed01a",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.28.0/op_linux_amd64_v2.28.0.zip": "a0732965d86c4429b508d1f00531359936a50d62f78b01fc2df964d9f5f47982",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.28.0/op_apple_universal_v2.28.0.pkg": "e559a8816a8260c76b83d77246de25bab3e6491754507b782d3de590e10a7442",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.29.0/op_apple_universal_v2.29.0.pkg": "febca49599c686b8098200c86bc1e6b83b0701791dad6797282406195c14000a",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.3/op_linux_amd64_v2.30.3.zip": "a16307ebcecb40fd091d7a6ff4f0c380c3c0897c4f4616de2c5d285e57d5ee28",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.19.0/op_linux_amd64_v2.19.0.zip": "1d5d084f58a7308d36dd1d1717b32629394e806b72c21ddee9573f9e02fbd5d3",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.29.0/op_linux_amd64_v2.29.0.zip": "5710c97b87d971805560c1c717aad1a081d815ff696918b16e52211039311dc4",
-  "https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.3/op_apple_universal_v2.30.3.pkg": "4559e0ee1b997d1451f7d4cb2b09a6ba7eb0a1288884ce589da11f5a074f26be",
 }


### PR DESCRIPTION
# Summary

This PR changes `op.hcl` to install on darwin using `.zip` instead of `.pkg` as a workaround to the following error i was running into when attempting to `hermit install op`:

```
❯ hermit install op
info:op-2.30.3:install: Installing op-2.30.3
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ 2/2    100.0%

error:op-2.30.3:unpack: installer: Package name is 1Password CLI
installer: choices changes file '/var/folders/nm/c6s1vzx50fg47nzvqvltpfj80000gn/T/hermit-3056435625.xml' applied
installer: Installing at base path /Users/moegrammer
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing 1Password CLI….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: The install failed. (The Installer encountered an error that caused the installation to fail. Contact the software manufacturer for assistance. An unexpected error occurred while moving files to the final destination.)

fatal:hermit: installer -verbose -pkg /Users/moegrammer/Library/Caches/hermit/cache/85/851254208c174aed0d57fac8509c42eb054713ebd4b615e0f1cbe77e7b2403fe-op_apple_universal_v2.30.3.pkg -target CurrentUserHomeDirectory -applyChoiceChangesXML /var/folders/nm/c6s1vzx50fg47nzvqvltpfj80000gn/T/hermit-3056435625.xml failed: exit status 1
```

# Context
the error output seems to indicate that attempting to rename what's extracted from the `.pkg` to the desired path fails because the `from` doesn't actually exist.

I think we decided to use `.pkg` because the op cli didn't actually have a `.zip` available for darwin at the time. It looks like agilebits changed the release distributions they upload starting on 08-24-2024 (2.20.0):

<img width="459" alt="image" src="https://github.com/user-attachments/assets/52617771-4795-46f8-973a-6f06da7ee60a" />

> [!WARNING]
> The change i made could _potentially_ be considered heavy handed because i'm not sure if people who already have `op` v2.18.0 or 2.19.0 installed via hermit will be able to easily upgrade without uninstalling first. i also removed those versions. I made the change in this way because it simplified the manifest and i saw `-applyChoiceChangesXML` in the failure log and didn't want to deal with or think about XML 😅 