### PR TITLE
fix[hadolint]: use xarch var instead of arch

### DIFF
--- a/hadolint.hcl
+++ b/hadolint.hcl
@@ -1,10 +1,10 @@
 description = "Dockerfile linter, validate inline bash, written in Haskell"
 binaries = ["hadolint"]
-source = "https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-${os}-${arch}"
+source = "https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-${os}-${xarch}"
 
 on "unpack" {
   rename {
-    from = "${root}/hadolint-${os}-${arch}"
+    from = "${root}/hadolint-${os}-${xarch}"
     to = "${root}/hadolint"
   }
 }

--- a/hadolint.hcl
+++ b/hadolint.hcl
@@ -10,6 +10,13 @@ platform "amd64" {
     "arch_": "x86_64",
   }
 }
+
+platform "arm64" {
+  vars = {
+    "arch_": "x86_64",
+  }
+}
+
 on "unpack" {
   rename {
     from = "${root}/hadolint-${os}-${arch_}"

--- a/hadolint.hcl
+++ b/hadolint.hcl
@@ -1,10 +1,18 @@
 description = "Dockerfile linter, validate inline bash, written in Haskell"
 binaries = ["hadolint"]
-source = "https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-${os}-${xarch}"
+source = "https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-${os}-${arch_}"
+vars = {
+  "arch_": "${arch}",
+}
 
+platform "amd64" {
+  vars = {
+    "arch_": "x86_64",
+  }
+}
 on "unpack" {
   rename {
-    from = "${root}/hadolint-${os}-${xarch}"
+    from = "${root}/hadolint-${os}-${arch_}"
     to = "${root}/hadolint"
   }
 }


### PR DESCRIPTION
use xarch (resolves to x86_64) var instead of arch (resolves to amd64)

error message:
`fatal:hermit: https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-linux-amd64: download failed: 404 Not Found (404), source url: https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-linux-amd64`