### PR TITLE
fix(gradle): use releases page for auto-versioning

### DIFF
--- a/gradle.hcl
+++ b/gradle.hcl
@@ -9,7 +9,10 @@ version "6.7" "6.8.3" "7.0" "7.1" "7.2" "7.3.2" "7.4.2" "7.5" "7.6" "7.6.1" "7.6
         "7.6.3" "8.0-rc-2" "8.0.1" "8.0.2" "8.1.1" "8.2" "8.2.1" "8.3" "8.4" "8.5" "8.6" "8.7"
         "8.8" "8.9" "8.10" "8.10.1" "8.10.2" "8.11" "8.11.1" "8.12" "8.12.1" "8.13" {
   auto-version {
-    github-release = "gradle/gradle"
+    html {
+      url = "https://gradle.org/releases/"
+      css = "div.resources-contents h3 span:last-child"
+    }
   }
 }
 


### PR DESCRIPTION
Rather than GitHub releases which uses tags (eg. v8.13.0) that don't match the actual version (8.13).