### PR TITLE
fix: Add jlumbroso/free-disk-space to maximize disk space

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -7,6 +7,12 @@ jobs:
   auto-version:
     runs-on: ubuntu-latest
     steps:
+      # Free disk space to avoid running into "No space left on device" errors
+      - name: Maximize Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+
       - uses: actions/checkout@v2
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV


### PR DESCRIPTION
## 📝 Description
we recently added optional support for checksumming linux/arm64 binaries, so Hermit will be backfilling those for all packages. This has been manually run locally to catch it up, which should unblock future runs.

However, this step can help reduce the change of running out of spaces in the future


