### PR TITLE
Add latest python3 version: 3.13.2

### DIFF
--- a/python3.hcl
+++ b/python3.hcl
@@ -122,6 +122,12 @@ version "3.8.19" "3.9.19" "3.10.14" "3.11.9" "3.12.3" {
   }
 }
 
+version "3.13.2" {
+  vars = {
+    "release_date": "20250317",
+  }
+}
+
 sha256sums = {
   "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-gnu-pgo+lto-20210506T0943.tar.zst": "aec8c4c53373b90be7e2131093caa26063be6d9d826f599c935c0e1042af3355",
   "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo+lto-20210506T0943.tar.zst": "8d06bec08db8cdd0f64f4f05ee892cf2fcbc58cfb1dd69da2caab78fac420238",
@@ -264,5 +270,9 @@ sha256sums = {
   "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7+20221002-aarch64-unknown-linux-gnu-lto-full.tar.zst": "f92fb53661f2ceddeb7b15ae1f165671acf4e4d4f9519a87e033981b93ee33b8",
   "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11+20230507-aarch64-unknown-linux-gnu-lto-full.tar.zst": "2e304c39d8af27f9abf1cf44653f5e34e7d05b665cb68e5a5474559c145e7b33",
   "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12+20230726-aarch64-unknown-linux-gnu-lto-full.tar.zst": "bb5fa1d4ad202afc8ee4330f313c093760c9fb1af5be204dc0c6ba50c7610fea",
-  "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8+20240224-aarch64-unknown-linux-gnu-lto-full.tar.zst": "1d84ed69e5acce555513e9261ce4b78bed19969b06a51a26b2781a375d70083d",
+  "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8+20240224-aarch64-unknown-linux-gnu-lto-full.tar.zst": "1d84ed69e5acce555513e9261ce4b78bed19969b06a51a26b2781a375d70083d",  
+  "https://github.com/indygreg/python-build-standalone/releases/download/20250317/cpython-3.13.2+20250317-x86_64-unknown-linux-gnu-pgo+lto-full.tar.zst": "785312cb9cdf32d355711067c0c5eebbe9c64422881b3e7bd28dc89c9fe13c2e",
+  "https://github.com/indygreg/python-build-standalone/releases/download/20250317/cpython-3.13.2+20250317-x86_64-apple-darwin-pgo+lto-full.tar.zst": "b9cb3146f59fdd25025500f5df4b6910742aee44856a99f82e612db97f08dcaf",
+  "https://github.com/indygreg/python-build-standalone/releases/download/20250317/cpython-3.13.2+20250317-aarch64-apple-darwin-pgo+lto-full.tar.zst": "4b38e0badf5fadd5866be5aebc00e9f9b1de26d60164c4c2cc4b8c0f8edb8ece",
+  "https://github.com/indygreg/python-build-standalone/releases/download/20250317/cpython-3.13.2+20250317-aarch64-unknown-linux-gnu-lto-full.tar.zst": "caf3b90db6f9738a7e1b4de4c2f7e7b80b5b8198306eaeb4a60f2602697daafb",
 }


### PR DESCRIPTION
This adds the latest python3 version. The release page is here: https://www.python.org/downloads/release/python-3132/