### PR TITLE
Add gke-gcloud-auth-plugin package

### DIFF
--- a/gke-gcloud-auth-plugin.hcl
+++ b/gke-gcloud-auth-plugin.hcl
@@ -44,10 +44,22 @@ version "0.5.10" {
       }
     }
   }
+
+  platform "linux" "arm64" {
+    source = "https://dl.google.com/dl/cloudsdk/channels/rapid/components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-arm-20250117151628.tar.gz"
+
+    on "unpack" {
+      chmod {
+        file = "${root}/bin/gke-gcloud-auth-plugin"
+        mode = 0755
+      }
+    }
+  }
 }
 
 sha256sums = {
   "https://dl.google.com/dl/cloudsdk/channels/rapid/components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86_64-20250117151628.tar.gz": "4be17cd481e9153bf5ad23e066628562551a0b9d5e05495b1b625cc49a5e73da",
   "https://dl.google.com/dl/cloudsdk/channels/rapid/components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-x86_64-20250117151628.tar.gz": "9910b17c2ecde0a5ae498ed4f2de10051ebc90d2cbfdc78d4cd94394668f2849",
   "https://dl.google.com/dl/cloudsdk/channels/rapid/components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-arm-20250117151628.tar.gz": "ef0f048e38b665759c3c147f78e436f65e4974c779870aca1cf7473b898a4748",
+  "https://dl.google.com/dl/cloudsdk/channels/rapid/components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-arm-20250117151628.tar.gz": "c64b26fa47351f1a278f660ab3ae871855f35b52215592e7777afdd5515b9c35",
 }


### PR DESCRIPTION
## Summary
- Adds the official Google Cloud GKE authentication plugin for kubectl
- Provides the `gke-gcloud-auth-plugin` binary that replaces legacy gcloud-based authentication for GKE clusters
- Includes proper runtime dependency on gcloud and environment variable configuration

## Test plan
- [x] Package validates successfully with `hermit validate`
- [x] Binary installs and runs (`gke-gcloud-auth-plugin --version`)
- [x] Package test passes (`hermit test -t gke-gcloud-auth-plugin`)
- [x] Executable permissions work correctly after installation
- [x] Environment variable `USE_GKE_GCLOUD_AUTH_PLUGIN=True` is set properly