### PR TITLE
uv: Add PYTHONUSERBASE env to uv

### DIFF
--- a/uv.hcl
+++ b/uv.hcl
@@ -37,6 +37,10 @@ version "0.1.1" "0.1.3" "0.1.4" "0.1.5" "0.1.6" "0.1.8" "0.1.10" "0.1.11" "0.1.1
   }
 }
 
+env = {
+  "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
+}
+
 sha256sums = {
   "https://github.com/astral-sh/uv/releases/download/0.1.1/uv-x86_64-apple-darwin.tar.gz": "dde96aad74a1abd6ba3440eceebca2a5c9f29aecf9178dda0b10d1177cfa3a8d",
   "https://github.com/astral-sh/uv/releases/download/0.1.1/uv-aarch64-apple-darwin.tar.gz": "ff595133104cd486c7d852f68d5fa82bafddc7cedcc5087432fd55f0681af89a",

--- a/uv.hcl
+++ b/uv.hcl
@@ -3,6 +3,10 @@ binaries = ["*"]
 homepage = "https://astral.sh/"
 strip = 1
 
+env = {
+  "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
+}
+
 platform "darwin" {
   source = "https://github.com/astral-sh/uv/releases/download/${version}/uv-${xarch}-apple-darwin.tar.gz"
   sha256-source = "https://github.com/astral-sh/uv/releases/download/${version}/uv-${xarch}-apple-darwin.tar.gz.sha256"
@@ -35,10 +39,6 @@ version "0.1.1" "0.1.3" "0.1.4" "0.1.5" "0.1.6" "0.1.8" "0.1.10" "0.1.11" "0.1.1
   auto-version {
     github-release = "astral-sh/uv"
   }
-}
-
-env = {
-  "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
 }
 
 sha256sums = {


### PR DESCRIPTION
Adding the PYTHONUSERBASE env variable to uv the same as python3.hcl allowing better compatibility between existing python/pip and uv, allowing the one to use both pip and uv inter-changablity.