### PR TITLE
[Test/CI Round 2] uv: Add PYTHONUSERBASE env to uv

### DIFF
--- a/uv.hcl
+++ b/uv.hcl
@@ -2,6 +2,9 @@ description = "An extremely fast Python package installer and resolver, written 
 binaries = ["*"]
 homepage = "https://astral.sh/"
 strip = 1
+env = {
+  "PYTHONUSERBASE": "${HERMIT_ENV}/.hermit/python",
+}
 
 platform "darwin" {
   source = "https://github.com/astral-sh/uv/releases/download/${version}/uv-${xarch}-apple-darwin.tar.gz"


### PR DESCRIPTION
> Adding the PYTHONUSERBASE env variable to uv the same as python3.hcl allowing better compatibility between existing python/pip and uv, allowing the one to use both pip and uv inter-changablity.

Recreating from this [PR](https://github.com/cashapp/hermit-packages/pull/631) to debug the failing CI