### PR TITLE
chore(ci): hopefully ensure that packages are tested if there are errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,7 @@ jobs:
           ~/bin/hermit validate "file://$PWD"
           ~/bin/hermit init --sources="file://$PWD" ./testenv
           . ./testenv/bin/activate-hermit
-          for pkg in $(git diff --name-only $(git merge-base origin/master HEAD) | fgrep .hcl | cut -d. -f1 | xargs -I{} -n1 hermit search -s '^{}$' | grep -v '@'); do echo $pkg; hermit test -t $pkg; hermit clean -tp; done
+          for pkg in $(git diff --name-only $(git merge-base origin/master HEAD) | fgrep .hcl | cut -d. -f1); do
+            hermit test -t "$pkg"
+            hermit clean -tp
+          done


### PR DESCRIPTION
`hermit search -s <pkg>` will ignore manifest errors, deliberately, but as that was what was used to test new/updated packages, they would be completely skipped.

This PR changes the approach so that the package is always tested. It also skips the full set of version tests, because that slowly becomes more and more untenable as packages accrue versions.