### PR TITLE
zellij: fix sha256-source url and wrong checksum

### DIFF
--- a/zellij.hcl
+++ b/zellij.hcl
@@ -4,7 +4,7 @@ test = "zellij --version"
 
 linux {
   source = "https://github.com/zellij-org/zellij/releases/download/v${version}/zellij-no-web-${xarch}-unknown-linux-musl.tar.gz"
-  sha256-source = "https://github.com/zellij-org/zellij/releases/download/v${version}/zellij-${xarch}-unknown-linux-musl.sha256sum"
+  sha256-source = "https://github.com/zellij-org/zellij/releases/download/v${version}/zellij-no-web-${xarch}-unknown-linux-musl.sha256sum"
 }
 
 darwin {
@@ -23,7 +23,7 @@ sha256sums = {
   "https://github.com/zellij-org/zellij/releases/download/v0.43.1/zellij-x86_64-apple-darwin.tar.gz": "7b0c1a9c2591eadf506ec58d62ef5f6d9c93d089a3603142af3dcca5fa575d44",
   "https://github.com/zellij-org/zellij/releases/download/v0.43.1/zellij-aarch64-apple-darwin.tar.gz": "a09ea51f3d98427253de2b889bb04f1aa0850fbb034911c7a01b8f0194edba66",
   "https://github.com/zellij-org/zellij/releases/download/v0.43.1/zellij-no-web-aarch64-unknown-linux-musl.tar.gz": "8ced877df27a8fe9112607dd3d772442aefa5e42359cda1baba53e78c4ae46aa",
-  "https://github.com/zellij-org/zellij/releases/download/v0.44.0/zellij-no-web-x86_64-unknown-linux-musl.tar.gz": "d7239c8f8c08dc7bb73920fa7757d776a81f899a45edfc1d0c862a0368db7127",
+  "https://github.com/zellij-org/zellij/releases/download/v0.44.0/zellij-no-web-x86_64-unknown-linux-musl.tar.gz": "458b0c5ec19d6313580293e451c9a467c73b337d42faf8e2ce1712c56767b727",
   "https://github.com/zellij-org/zellij/releases/download/v0.44.0/zellij-x86_64-apple-darwin.tar.gz": "aa95a65c99ac9b9e609411ca0897f3778d2cd8a8363c71b61b68101758532b14",
   "https://github.com/zellij-org/zellij/releases/download/v0.44.0/zellij-aarch64-apple-darwin.tar.gz": "89a9273955c64bfafa1325e227a6c3bb3b81c2648b5999a69d57f6728933b1b8",
   "https://github.com/zellij-org/zellij/releases/download/v0.44.0/zellij-no-web-aarch64-unknown-linux-musl.tar.gz": "4b2d47a210dcaabde40e659bfb00677d2dccce2238e562a145fe8df68a35b6c4",


### PR DESCRIPTION
Root cause: the linux package block was trying to download the zellij-no-web-... tarball, but its sha256-source was mistakenly pointing to the standard zellij-... .sha256sum file. This caused hermit to populate the sha256sums block with the checksum of the standard version (d7239...) instead of the no-web version (458b0...).

Started failing after: https://github.com/cashapp/hermit-packages/commit/b4ca316e5742acbc778245a43812a4e7df787e1f