### PR TITLE
Make platform blocks explicit for opa and yajsv

### DIFF
--- a/opa.hcl
+++ b/opa.hcl
@@ -3,7 +3,7 @@ binaries = ["opa"]
 test = "opa version"
 
 version "0.30.1" {
-  linux {
+  platform "linux" "amd64" {
     source = "https://github.com/open-policy-agent/opa/releases/download/v${version}/opa_linux_amd64"
 
     on "unpack" {
@@ -14,7 +14,7 @@ version "0.30.1" {
     }
   }
 
-  darwin {
+  platform "darwin" "amd64" {
     source = "https://github.com/open-policy-agent/opa/releases/download/v${version}/opa_darwin_amd64"
 
     on "unpack" {

--- a/yajsv.hcl
+++ b/yajsv.hcl
@@ -1,12 +1,26 @@
 description = "Yet Another JSON Schema Validator [CLI]"
 homepage = "https://json-schema.org/"
 binaries = ["yajsv"]
-source = "https://github.com/neilpa/yajsv/releases/download/v${version}/yajsv.${os}.amd64"
 
-on "unpack" {
-  rename {
-    from = "${root}/yajsv.${os}.amd64"
-    to = "${root}/yajsv"
+platform "linux" "amd64" {
+  source = "https://github.com/neilpa/yajsv/releases/download/v${version}/yajsv.linux.amd64"
+
+  on "unpack" {
+    rename {
+      from = "${root}/yajsv.linux.amd64"
+      to = "${root}/yajsv"
+    }
+  }
+}
+
+darwin {
+  source = "https://github.com/neilpa/yajsv/releases/download/v${version}/yajsv.darwin.amd64"
+
+  on "unpack" {
+    rename {
+      from = "${root}/yajsv.darwin.amd64"
+      to = "${root}/yajsv"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- **opa.hcl**: Change `linux {}` and `darwin {}` to `platform "linux" "amd64" {}` and `platform "darwin" "amd64" {}` in the v0.30.1 block so hermit doesn't try to install amd64 binaries on arm64 machines. Newer versions (0.38.1+) already use `${arch}` and support arm64 natively.
- **yajsv.hcl**: Replace top-level source (which matched all platforms including arm64) with explicit `platform "linux" "amd64" {}` block since no linux-arm64 binary exists. Darwin keeps the arch-unqualified block (works via Rosetta on arm64 macs).

Same pattern as #747 (codecov).