### PR TITLE
feat(pnpm): add pnpm 11 support (.tar.gz archive format)

### DIFF
--- a/pnpm.hcl
+++ b/pnpm.hcl
@@ -64,6 +64,35 @@ version "7.33.7" "8.14.1" "8.14.2" "8.14.3" "8.15.0" "8.15.1" "8.15.2" "8.15.3"
         "10.32.0" "10.32.1" "10.33.0" "10.33.1" "10.33.2" {
   auto-version {
     github-release = "pnpm/pnpm"
+    // Constrain to <= 10.x so v11+ tags route to the dedicated 11+ block.
+    // (Without a pattern, hermit's default `v?(.*)` would match every tag
+    // and append v11+ here too — those URLs don't exist for v11+.)
+    version-pattern         = "v([0-9]\\..*|10\\..*)"
+    ignore-invalid-versions = true
+  }
+}
+
+// pnpm 11+ ships as `.tar.gz` archives instead of bare binaries, AND
+// renames macOS assets from `macos-*` to `darwin-*` so they line up with
+// `${os}` on both Linux and Darwin (canonical write-up:
+// https://github.com/pnpm/pnpm/issues/11314, release notes:
+// https://github.com/pnpm/pnpm/releases/tag/v11.0.0).
+// The archive extracts a `pnpm` binary alongside a `dist/` directory of
+// supporting Node SEA resources, both relative to ${root}.
+version "11.0.0" {
+  platform "amd64" {
+    source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-x64.tar.gz"
+  }
+
+  platform "arm64" {
+    source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-${arch}.tar.gz"
+  }
+
+  auto-version {
+    github-release = "pnpm/pnpm"
+    // Match major version >= 11 (covers 11-19, 20-99, and 100+).
+    version-pattern         = "v(1[1-9]\\..*|[2-9][0-9]\\..*|[1-9][0-9]{2,}\\..*)"
+    ignore-invalid-versions = true
   }
 }
 
@@ -508,4 +537,8 @@ sha256sums = {
   "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64": "39d7b6600239712bc9581ea219b17ffef46ba60998779cb717be2e068be029ef",
   "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-arm64": "0828e5ee23be89d22bd53cc36e93c181ce9d5c47d75f9fe9bf4bdc7a65c66322",
   "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-macos-x64": "3b66abb865f4e7a82393861f0f3784d67a704a31a4021739874d4b7910793dca",
+  "https://github.com/pnpm/pnpm/releases/download/v11.0.0/pnpm-darwin-arm64.tar.gz": "3620a0fcaf81ecd3aaeccd5965919d90dbc913f4d07a96e11e7cafc2c785054b",
+  "https://github.com/pnpm/pnpm/releases/download/v11.0.0/pnpm-darwin-x64.tar.gz": "1701748b75187f1333a9c616827943ff84ff46cc42becc156ff6864b9bd0f948",
+  "https://github.com/pnpm/pnpm/releases/download/v11.0.0/pnpm-linux-x64.tar.gz": "9b44acc77ada40fc41b665fde1d57367a5ebec31bd4b1b00598daed195da3e17",
+  "https://github.com/pnpm/pnpm/releases/download/v11.0.0/pnpm-linux-arm64.tar.gz": "1e6d87ebfd7ff169966ff5b3ad71b780b883c68d3e59987df1096dfd8853df75",
 }


### PR DESCRIPTION
## Context

[pnpm 11.0.0](https://github.com/pnpm/pnpm/releases/tag/v11.0.0) was released on 2026-04-28 and renamed its platform-specific release assets to a new `<platform>-<arch>[-<libc>]` scheme to align with `process.platform`/`process.arch` and the rest of the npm/Node.js ecosystem. The canonical write-up is [pnpm/pnpm#11314](https://github.com/pnpm/pnpm/issues/11314), which includes the full before → after table:

| today (≤10.x) | new (11+) |
|---|---|
| `pnpm-macos-x64` (bare binary) | `pnpm-darwin-x64.tar.gz` |
| `pnpm-macos-arm64` (bare binary) | `pnpm-darwin-arm64.tar.gz` |
| `pnpm-linux-x64` (bare binary) | `pnpm-linux-x64.tar.gz` |
| `pnpm-linux-arm64` (bare binary) | `pnpm-linux-arm64.tar.gz` |

Two things changed at once for v11:
1. **Filename rename** (`macos-*` → `darwin-*`, `linuxstatic-*` → `linux-*-musl`)
2. **Distribution format** (bare binary → `.tar.gz` containing a Node SEA `pnpm` executable + sibling `dist/` directory of supporting resources, since pnpm switched from `@yao-pkg/pkg` to native Node SEA)

## Problem

The existing `pnpm.hcl` platform blocks point at the legacy bare-binary URL pattern:

```hcl
source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-x64"
```

That URL 404s for v11+ because no such asset exists. As a result, the auto-versioner has been silently skipping every `v11.0.0-rc.*` and now `v11.0.0` tag — `pnpm.hcl` still tops out at `10.33.2` even though v11 has been GA for over a week.

## Solution

Add a dedicated `version "11.0.0"` block with platform overrides that point at the new `pnpm-{os}-{arch}.tar.gz` URLs. Hermit's default unpack handles the archive correctly: the binary lands at `${root}/pnpm` and the `dist/` folder lands alongside it, which is exactly the layout the SEA binary expects. No `strip`, no `rename`, no extra `on "unpack"` rules needed (verified against other manifests like `sq.hcl` that use `.tar.gz` sources without explicit unpack rules).

Because the `darwin-*` rename means v11 asset names finally line up with hermit's `${os}` (`darwin`/`linux`), the v11 block only needs two `platform` declarations (`amd64` / `arm64`) instead of the four-block per-OS layout the legacy block uses.

### Auto-version routing

Both the existing block and the new block target the same `github-release = "pnpm/pnpm"` source. Since hermit's auto-versioner appends a new release to **every** block whose `version-pattern` matches (it doesn't probe asset URLs to decide), both blocks need mutually-exclusive patterns to route correctly:

- Legacy block: `version-pattern = "v([0-9]\\..*|10\\..*)"` — picks up future 10.x patches via the legacy bare-binary URLs
- New block: `version-pattern = "v(1[1-9]\\..*|[2-9][0-9]\\..*|[1-9][0-9]{2,}\\..*)"` — picks up future 11.x, 12.x, …, 100+.x via the new `.tar.gz` URLs

Both also set `ignore-invalid-versions = true` so a single `auto-version` run doesn't hard-error when the latest release doesn't match one of the two patterns.

This mirrors the per-major-version pattern already used in [`node.hcl`](https://github.com/cashapp/hermit-packages/blob/master/node.hcl).

## Test Steps

1. `hermit manifest validate file:///path/to/this/checkout` — passes
2. Manually downloaded `pnpm-darwin-arm64.tar.gz` from the v11.0.0 release, extracted with `tar -xz`, ran `./pnpm --version` from a directory with no parent `packageManager` field — reports `11.0.0` ✅
3. Confirmed the archive layout matches the manifest's assumption (`pnpm` binary + `dist/` folder at top level, no wrapper directory)
4. Verified all 4 v11.0.0 release asset URLs return HTTP 200 with non-zero content-length, and that the SHA256 keys in the manifest exactly match the URLs the platform template will generate

## Notes

- The 4 sha256s correspond to the official v11.0.0 release assets and were captured locally with `shasum -a 256`
- The SEA binary respects `NODE_OPTIONS` (verified separately), which fixes a long-standing OOM issue some consumers hit in CI on pnpm 10's pkg-based binary
- Windows isn't touched here because the existing `pnpm.hcl` doesn't have a `platform "windows"` block; if/when that's added, the v11 source would be `pnpm-win32-{arch}.zip` per [#11314](https://github.com/pnpm/pnpm/issues/11314)

🤖 Generated with [Amp](https://ampcode.com)
