### PR TITLE
fix(pnpm): move legacy rename triggers into the v10.x version block

### DIFF
--- a/pnpm.hcl
+++ b/pnpm.hcl
@@ -7,46 +7,18 @@ env = {
 
 platform "linux" "amd64" {
   source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-x64"
-
-  on "unpack" {
-    rename {
-      from = "${root}/pnpm-${os}-x64"
-      to = "${root}/pnpm"
-    }
-  }
 }
 
 platform "linux" "arm64" {
   source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-${arch}"
-
-  on "unpack" {
-    rename {
-      from = "${root}/pnpm-${os}-arm64"
-      to = "${root}/pnpm"
-    }
-  }
 }
 
 platform "darwin" "amd64" {
   source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-macos-x64"
-
-  on "unpack" {
-    rename {
-      from = "${root}/pnpm-macos-x64"
-      to = "${root}/pnpm"
-    }
-  }
 }
 
 platform "darwin" "arm64" {
   source = "https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-macos-${arch}"
-
-  on "unpack" {
-    rename {
-      from = "${root}/pnpm-macos-${arch}"
-      to = "${root}/pnpm"
-    }
-  }
 }
 
 version "7.33.7" "8.14.1" "8.14.2" "8.14.3" "8.15.0" "8.15.1" "8.15.2" "8.15.3"
@@ -62,6 +34,50 @@ version "7.33.7" "8.14.1" "8.14.2" "8.14.3" "8.15.0" "8.15.1" "8.15.2" "8.15.3"
         "10.25.0" "10.26.0" "10.26.1" "10.26.2" "10.27.0" "10.28.0" "10.28.1" "10.28.2"
         "10.29.1" "10.29.2" "10.29.3" "10.30.0" "10.30.1" "10.30.2" "10.30.3" "10.31.0"
         "10.32.0" "10.32.1" "10.33.0" "10.33.1" "10.33.2" {
+  // pnpm <= 10.x ships as bare per-platform binaries (e.g. `pnpm-darwin-arm64`)
+  // that need to be renamed to `pnpm` after unpack. The rename rule MUST live
+  // inside this version block (rather than at top-level platform scope) because
+  // hermit's layer model APPENDS `on "unpack"` triggers from every matching
+  // layer with no suppression mechanism — see manifest/resolver.go newPackage
+  // and manifest/config.go layers(). If the rename were at top level it would
+  // also fire for the v11+ block below (which extracts a `pnpm` binary directly
+  // from a .tar.gz archive), failing with `rename ... no such file or directory`.
+  platform "linux" "amd64" {
+    on "unpack" {
+      rename {
+        from = "${root}/pnpm-${os}-x64"
+        to = "${root}/pnpm"
+      }
+    }
+  }
+
+  platform "linux" "arm64" {
+    on "unpack" {
+      rename {
+        from = "${root}/pnpm-${os}-arm64"
+        to = "${root}/pnpm"
+      }
+    }
+  }
+
+  platform "darwin" "amd64" {
+    on "unpack" {
+      rename {
+        from = "${root}/pnpm-macos-x64"
+        to = "${root}/pnpm"
+      }
+    }
+  }
+
+  platform "darwin" "arm64" {
+    on "unpack" {
+      rename {
+        from = "${root}/pnpm-macos-${arch}"
+        to = "${root}/pnpm"
+      }
+    }
+  }
+
   auto-version {
     github-release = "pnpm/pnpm"
     // Constrain to <= 10.x so v11+ tags route to the dedicated 11+ block.


### PR DESCRIPTION
Follow-up to #753.

PR #753 added pnpm 11 support (.tar.gz archive format) but inadvertently introduced a regression: every `hermit install pnpm-11.x` fails with:

```
fatal:hermit: rename .../pkg/pnpm-11.0.3/pnpm-macos-arm64 .../pnpm: no such file or directory
```

## Root cause

Hermit composes `on "unpack"` triggers by **appending** actions from every matching layer in the resolved layer stack — there is no syntactic way to clear or override an inherited trigger. See [`manifest/config.go: layers()`](https://github.com/cashapp/hermit/blob/master/manifest/config.go#L53-L84) and [`manifest/resolver.go: newPackage()`](https://github.com/cashapp/hermit/blob/master/manifest/resolver.go#L507-L511) (`p.Triggers[event] = append(...)`).

The four top-level `platform` blocks in `pnpm.hcl` each declared:

```hcl
on "unpack" {
  rename { from = "${root}/pnpm-macos-${arch}" to = "${root}/pnpm" }
}
```

These rename rules are correct for v10.x and earlier (which ship as bare per-platform binaries like `pnpm-darwin-arm64`). For v11+ the source is a `.tar.gz` that extracts a `pnpm` binary directly, so the inherited rename has no source file and the install aborts after extraction. The v11.x version block declares its own per-platform `source = ...` but cannot override or suppress the inherited `on "unpack"` trigger.

## Fix

Move the rename triggers from top-level platform scope into the legacy `version "7.33.7" ... "10.33.2"` block, scoped per platform. The top-level platform blocks now contain only `source = ...`, so the v11+ `version` block resolves with no inherited renames.

Inline comment added explaining why the structure is the way it is so the next person to touch this file doesn't unwittingly re-collapse the renames back into the top-level platform blocks.

## Verification

Manually patched the local hermit cache copy of `pnpm.hcl` with the same restructure and confirmed:

- `hermit install pnpm-10.18.3` (legacy bare binary) succeeds, produces a working `pkg/pnpm-10.18.3/pnpm` (62 MB, version 10.18.3).
- `hermit install pnpm-11.0.3` (new tarball format) succeeds, produces a working `pkg/pnpm-11.0.3/pnpm` (133 MB SEA binary, version 11.0.3) with `dist/` siblings intact.

Without this patch, `hermit install pnpm-11.0.3` against the published manifest fails with the rename error above on every platform / arch.

🤖 Generated with [Amp](https://ampcode.com)
