### PR TITLE
ruby: add versions 3.2.11, 3.3.11, 3.4.9, 4.0.2-4.0.5 from rv-ruby release 20260520

### DIFF
--- a/ruby.hcl
+++ b/ruby.hcl
@@ -52,6 +52,28 @@ version "3.2.10" "3.3.9" "3.3.10" "3.4.7" "3.4.8" "4.0.0" "4.0.1" {
   }
 }
 
+version "3.2.11" "3.3.11" "3.4.9" "4.0.2" "4.0.3" "4.0.4" "4.0.5" {
+  vars = {
+    "rv_release": "20260520",
+  }
+
+  platform "darwin" "arm64" {
+    source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.arm64_sonoma.tar.gz"
+  }
+
+  platform "darwin" "amd64" {
+    source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.ventura.tar.gz"
+  }
+
+  platform "linux" "amd64" {
+    source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.x86_64_linux.tar.gz"
+  }
+
+  platform "linux" "arm64" {
+    source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.arm64_linux.tar.gz"
+  }
+}
+
 sha256sums = {
   "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.6.8_1/portable-ruby-2.6.8_1.x86_64_linux.bottle.tar.gz": "fc45ee6eddf4c7a17f4373dde7b1bc8a58255ea61e6847d3bf895225b28d072a",
   "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.6.8_1/portable-ruby-2.6.8_1.el_capitan.bottle.tar.gz": "1f50bf80583bd436c9542d4fa5ad47df0ef0f0bea22ae710c4f04c42d7560bca",
@@ -138,4 +160,32 @@ sha256sums = {
   "https://github.com/spinel-coop/rv-ruby/releases/download/20260221/ruby-4.0.1.ventura.tar.gz": "d4c3bc5ab63597a18af2c773cf2c2d9ea182bf3bb0cd1bcb020af40a979f7d66",
   "https://github.com/spinel-coop/rv-ruby/releases/download/20260221/ruby-4.0.1.x86_64_linux.tar.gz": "cd2683fed356333a82093f43beae3cdfee22755978f88956bfb6a9b1e9f888f9",
   "https://github.com/spinel-coop/rv-ruby/releases/download/20260221/ruby-4.0.1.arm64_linux.tar.gz": "8fc30c107f969331ec2f1a67f80b77d977e43e255a27b2a3322fbe3268e23f52",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.2.11.arm64_linux.tar.gz": "e34788c76859ffe51f6794d2630ab232561aebd7fc1c93b2293a1bf3a01d15d1",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.2.11.x86_64_linux.tar.gz": "e2c287b0d4cb9418c950ae9aa5875df44c73e61d9a6d06d4306ecffd73e5f0b9",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.3.11.x86_64_linux.tar.gz": "57dba9901fab42cb6fd81d749bc96a7ff536d68d8ba1fb2824546604bf7ff59b",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.4.9.arm64_linux.tar.gz": "602170b5a78784085cf4c4917fa818ee2e1b786c1311ab6ce356cf6b5f8bdd3c",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.4.9.arm64_sonoma.tar.gz": "57b80ce7370c2b4fc2395c542c64310c5f280a5ad72265a5f71525e37c94cc62",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.2.ventura.tar.gz": "0abec55019c0af2b8dabd60aa7e6e1eafabb96b8a92653d8a2d460e8daecf5be",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.3.x86_64_linux.tar.gz": "6f17c755b00018636e99fc7b375504a4347bfe483a12596974994f0a88ae832f",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.3.ventura.tar.gz": "ab358a41909fef964ad0a6631dddc223710ca485284c96efe6fac0d81c6c4ab0",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.4.arm64_linux.tar.gz": "e673b8244634f1b854b69cdbc713cd4ddbc525e98671399496ff4e5616bf267b",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.5.x86_64_linux.tar.gz": "436be693e734a707e9dedc15530d1d0fe19614376a5361c4e4a140b67d3a676f",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.5.arm64_linux.tar.gz": "d8fc137d1cf7b0bb8e34ccc7654e3d5ee28bf7ba608b0e8c215174c4c93784f3",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.2.11.ventura.tar.gz": "25d92687bb078f179d6b25aca0a0667d16a5291b04efda1f6a877bbd83fbefb0",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.3.11.arm64_linux.tar.gz": "8e5cb7acce9172b4c307e5771bbfb759ab9772fc2fc4718d826b6873bc2a87b9",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.3.11.arm64_sonoma.tar.gz": "977b3785d6987336da83d26dba8e295979e55abcb17105c265408e0ddc9613b0",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.4.9.ventura.tar.gz": "75f205e4e5088816409cc99f78892d2b684cbff125d1cb1bba222ffec425d944",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.2.arm64_linux.tar.gz": "c3e2a4401419f415938d1e04ca9bf2d488a2656f2b69239ffbd019c87bbce3d0",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.2.arm64_sonoma.tar.gz": "a3543ab84ad812fb783406f3574c284e7210cfca19110da50f0ed69cdafb55b1",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.3.arm64_sonoma.tar.gz": "1b153670c921d784ada6b552a616f9fd5f833f4be507e8f43dcea1643eda5d1e",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.4.x86_64_linux.tar.gz": "a5d2853d553af39d82d3a797e43a58c19d54d356aaad8297ae253cce4e33d697",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.4.ventura.tar.gz": "6ddb43cc670700b1043263210eb670a4408ac611e571281bda7ad62ae14a111c",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.5.ventura.tar.gz": "199e54f9b61df320bbf253be141644874bdb7b5996fb1c8f90eccbbc7baf9421",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.5.arm64_sonoma.tar.gz": "8bd82c5f15ab947fc3bc8fdaa1a62a051d664d8be985c56c5f7c279371e85b60",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.2.11.arm64_sonoma.tar.gz": "54e916dc3f8a29674582d9122cc2a440523ee2f6ec29e623abcf7122afee212b",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.3.11.ventura.tar.gz": "8ac7894c6f73a996b4940db109519eebc456463d18de23d5f9c149f94de03f24",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-3.4.9.x86_64_linux.tar.gz": "8ec67793853b80fd7be64104ea1d2c503e001c13295dc56dc2c3cb176ecafe95",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.2.x86_64_linux.tar.gz": "bc2bc357074ae3a83519995852652079954e762d2998e6251f8a10a6ac548d77",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.3.arm64_linux.tar.gz": "75a459fef1045e7109e5730dd461383ea69dbf50a0da361218d9db3949af335c",
+  "https://github.com/spinel-coop/rv-ruby/releases/download/20260520/ruby-4.0.4.arm64_sonoma.tar.gz": "b118a200aa870847e755ed411a43be67d56c01931156cbe6067728c8426cb563",
 }


### PR DESCRIPTION
## Why
New stable Ruby releases (including the 4.0.2–4.0.5 series) are available from [spinel-coop/rv-ruby](https://github.com/spinel-coop/rv-ruby) release 20260520 but missing from the manifest.

## What
- Add versions 3.2.11, 3.3.11, 3.4.9, 4.0.2, 4.0.3, 4.0.4, 4.0.5 in a new version block pinned to `rv_release = "20260520"`
- Add sha256 digests for all four platforms (darwin/linux × amd64/arm64) via `hermit manifest add-digests`
- Prereleases (3.5.0-preview1, 4.0.0-preview2/3) and re-published older patch versions intentionally skipped

## Risk Assessment
Low — purely additive; existing version blocks and their pinned digests are unchanged.

## Test plan
- [x] Validated manifest: `hermit validate "file://$PWD"`
- [x] Tested installation: `hermit install ruby-3.4.9` and `hermit install ruby-4.0.5`
- [x] Verified binary works: `ruby --version` returns `ruby 3.4.9 ... +PRISM [arm64-darwin23]` / `ruby 4.0.5 ...`

Generated with [Claude Code](https://claude.ai/code)