### PR TITLE
Add Gradle 8.14.4 and 8.14.5

### DIFF
--- a/gradle.hcl
+++ b/gradle.hcl
@@ -8,7 +8,8 @@ repository = "https://github.com/gradle/gradle"
 version "6.7" "6.8.3" "7.0" "7.1" "7.2" "7.3.2" "7.4.2" "7.5" "7.6" "7.6.1" "7.6.2"
         "7.6.3" "8.0-rc-2" "8.0.1" "8.0.2" "8.1.1" "8.2" "8.2.1" "8.3" "8.4" "8.5" "8.6" "8.7"
         "8.8" "8.9" "8.10" "8.10.1" "8.10.2" "8.11" "8.11.1" "8.12" "8.12.1" "8.13" "8.14"
-        "8.14.1" "8.14.2" "8.14.3" "9.0.0" "9.1.0" "9.2.0" "9.2.1" "9.3.0" "9.3.1" "9.4.0"
+        "8.14.1" "8.14.2" "8.14.3" "8.14.4" "8.14.5" "9.0.0" "9.1.0" "9.2.0" "9.2.1" "9.3.0"
+        "9.3.1" "9.4.0"
         "9.4.1" "9.5.0" "9.5.1" {
   auto-version {
     html {
@@ -57,6 +58,8 @@ sha256sums = {
   "https://services.gradle.org/distributions/gradle-8.14.1-bin.zip": "845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf",
   "https://services.gradle.org/distributions/gradle-8.14.2-bin.zip": "7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999",
   "https://services.gradle.org/distributions/gradle-8.14.3-bin.zip": "bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531",
+  "https://services.gradle.org/distributions/gradle-8.14.4-bin.zip": "f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d",
+  "https://services.gradle.org/distributions/gradle-8.14.5-bin.zip": "6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854",
   "https://services.gradle.org/distributions/gradle-9.0.0-bin.zip": "8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b",
   "https://services.gradle.org/distributions/gradle-9.1.0-bin.zip": "a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806",
   "https://services.gradle.org/distributions/gradle-9.2.0-bin.zip": "df67a32e86e3276d011735facb1535f64d0d88df84fa87521e90becc2d735444",


### PR DESCRIPTION
Adds the two most recent Gradle 8.14.x patch releases to the gradle manifest:

- **8.14.4** (Jan 23, 2026)
- **8.14.5** (May 07, 2026)

### Why
The manifest's `auto-version` block tracks the *latest overall* Gradle release (currently the 9.x line), so the 8.14.x patch line stopped at 8.14.3 — 8.14.4 and 8.14.5 were never backfilled. Anyone pinned to the 8.14.x line can't `hermit install` them today.

This matters for Kotlin tooling in particular: **Kotlin Gradle Plugin 2.4.0 deprecates Gradle versions below 8.14.4** and makes 8.14.4 the minimum in Kotlin 2.5.0, so projects on the 8.14 line need 8.14.4+ to stay on a supported, non-deprecated Gradle.

### Checksums
Official values from https://gradle.org/release-checksums/, verified against the `*-bin.zip.sha256` sidecars:

| version | sha256 |
|---|---|
| gradle-8.14.4-bin.zip | `f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d` |
| gradle-8.14.5-bin.zip | `6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854` |

### Validation
`hermit install gradle-8.14.5` against this manifest resolves, downloads from `services.gradle.org`, and passes checksum verification locally.
