### PR TITLE
actionlint: fix auto-version trailing slash

### DIFF
--- a/actionlint.hcl
+++ b/actionlint.hcl
@@ -6,7 +6,7 @@ version "1.6.26" {
   source = "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_${os}_${arch}.tar.gz"
 
   auto-version {
-    github-release = "rhysd/actionlint/"
+    github-release = "rhysd/actionlint"
   }
 }
 


### PR DESCRIPTION
`github-release = "rhysd/actionlint/"` made Hermit build `https://api.github.com/repos/rhysd/actionlint//releases`, which 404s on the double slash. autoversion.yml runs with `--continue-on-error`, so the failure was swallowed and actionlint was silently frozen at 1.6.26 since it was added in #434 (Jan 2024), while upstream reached v1.7.12.

Dropping the slash lets the releases API call resolve again; the daily auto-version bot will append the latest version and digests on its next run. Verified locally: with the slash removed,
`hermit manifest auto-version --update-digests actionlint.hcl` resolves v1.7.12.