### PR TITLE
pre-commit.hcl: bump runtime-dependencies to python3@3.14

### DIFF
--- a/pre-commit.hcl
+++ b/pre-commit.hcl
@@ -2,7 +2,7 @@ description = "Pre-commit is a multi-language package manager for pre-commit hoo
 binaries = ["pre-commit"]
 test = "pre-commit --version"
 source = "https://github.com/pre-commit/pre-commit/releases/download/v${version}/pre-commit-${version}.pyz"
-runtime-dependencies = ["python3@3.9"]
+runtime-dependencies = ["python3@3.14"]
 dont-extract = true
 
 on "unpack" {


### PR DESCRIPTION
This PR update the runtime-dependencies of pre-commit to use the 3.14 channel of python3 in place of 3.9 as Python 3.9 has reached end-of-life.