### PR TITLE
fix broken `cargo-nextest.hcl` update URL

### DIFF
--- a/cargo-nextest.hcl
+++ b/cargo-nextest.hcl
@@ -3,15 +3,15 @@ description = "A next-generation test runner for Rust."
 binaries = ["cargo-nextest"]
 
 platform "darwin" {
-  source = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-universal-apple-darwin.tar.gz"
+  source = "https://github.com/nextest-rs/nextest/releases/download/${version}/${version}-universal-apple-darwin.tar.gz"
 }
 
 platform "linux" "amd64" {
-  source = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-${xarch}-unknown-linux-musl.tar.gz"
+  source = "https://github.com/nextest-rs/nextest/releases/download/${version}/${version}-${xarch}-unknown-linux-musl.tar.gz"
 }
 
 platform "linux" "arm64" {
-  source = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-${xarch}-unknown-linux-gnu.tar.gz"
+  source = "https://github.com/nextest-rs/nextest/releases/download/${version}/${version}-${xarch}-unknown-linux-gnu.tar.gz"
 }
 
 version "0.9.68" {


### PR DESCRIPTION
I noticed the `Auto-version` CI has been failing to update this package:

- https://github.com/cashapp/hermit-packages/actions/runs/29222227077/job/86729518406

```log
warn:cargo-nextest: Retrying. Failed to download any of https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz on attempt 1/3: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz
warn:cargo-nextest: Retrying. Failed to download any of https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz on attempt 2/3: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz
warn:cargo-nextest: Failed to download any of https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz on attempt 3/3: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz
warn:cargo-nextest: Retrying. Failed to download any of https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz on attempt 1/3: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz
warn:cargo-nextest: Retrying. Failed to download any of https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz on attempt 2/3: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz
warn:cargo-nextest: Failed to download any of https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz on attempt 3/3: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz
warn: Could not update digests for "/home/runner/work/hermit-packages/hermit-packages/cargo-nextest.hcl": failed to compute digest for cargo-nextest-cargo-nextest-0.9.140/linux-amd64: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz is unavailable: download failed: 404 Not Found (404), source url: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz
```

Because of the malformed URL:

- URL from the logs (incorrect): https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-cargo-nextest-0.9.140/cargo-nextest-cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz
- Correct URL: https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz

Checking `cargo-nextest.hcl`, I'm not sure why `${version}` has an extra `cargo-nextest-` prefix. Thoughts? suggestions on what to check/test next?

Thanks!
