### PR TITLE
Add exiftool package

### DIFF
--- a/exiftool.hcl
+++ b/exiftool.hcl
@@ -1,0 +1,19 @@
+description = "ExifTool is a platform-independent Perl library and command-line application for reading, writing, and editing metadata."
+homepage = "https://exiftool.org/"
+binaries = ["exiftool"]
+test = "exiftool -ver"
+strip = 1
+source = "https://downloads.sourceforge.net/project/exiftool/Image-ExifTool-${version}.tar.gz"
+
+version "13.59" {
+  auto-version {
+    html {
+      url = "https://exiftool.org/"
+      xpath = "replace((//a[contains(@href, 'Image-ExifTool-')])/@href, '^.*/Image-ExifTool-([0-9.]+)\\.tar\\.gz/download$', '$1')"
+    }
+  }
+}
+
+sha256sums = {
+  "https://downloads.sourceforge.net/project/exiftool/Image-ExifTool-13.59.tar.gz": "668ea3acececb7235fbd0f4900e72d5f12c9b07e5c778fd36cb1e9b5828fd65a",
+}


### PR DESCRIPTION
Adds [ExifTool](https://exiftool.org/) - a platform-independent metadata reader, writer, and editor.

## Test plan
- [x] Validated manifest: `~/bin/hermit validate "file://$PWD"`
- [x] Tested package: `~/bin/hermit test --no-check-sources exiftool-13.59`
- [x] Verified auto-versioning: `~/bin/hermit manifest auto-version exiftool.hcl`
- [x] Verified binary works: `exiftool -ver` returns `13.59` through the manifest test

🤖 Generated with Codex