### PR TITLE
Add Worktrunk package

### DIFF
--- a/worktrunk.hcl
+++ b/worktrunk.hcl
@@ -1,0 +1,44 @@
+homepage = "https://worktrunk.dev"
+description = "A CLI for Git worktree management, designed for parallel AI agent workflows"
+binaries = ["wt", "git-wt"]
+test = "wt --version"
+vars = {
+  "ext": "tar.xz",
+}
+
+platform "darwin" {
+  strip = 1
+  vars = {
+    "platform": "apple-darwin",
+  }
+}
+
+platform "linux" {
+  strip = 1
+  vars = {
+    "platform": "unknown-linux-musl",
+  }
+}
+
+platform "windows" "amd64" {
+  vars = {
+    "platform": "pc-windows-msvc",
+    "ext": "zip",
+  }
+}
+
+source = "https://github.com/max-sixty/worktrunk/releases/download/v${version}/worktrunk-${xarch}-${platform}.${ext}"
+
+version "0.74.0" {
+  auto-version {
+    github-release = "max-sixty/worktrunk"
+  }
+}
+
+sha256sums = {
+  "https://github.com/max-sixty/worktrunk/releases/download/v0.74.0/worktrunk-x86_64-apple-darwin.tar.xz": "5de8006b67fc04c2dfdeb3c5bc49479607aaff7e63ab3d47b4f21404cbe5375d",
+  "https://github.com/max-sixty/worktrunk/releases/download/v0.74.0/worktrunk-aarch64-apple-darwin.tar.xz": "d5ac03b8f3df0d144a2c052274b70a6f750a8c1e82b1b2ba348257749fda5ae3",
+  "https://github.com/max-sixty/worktrunk/releases/download/v0.74.0/worktrunk-aarch64-unknown-linux-musl.tar.xz": "24ad091af9fa3020b54101a4e0dc4ba17870d7e3da11d20f543b1ebd87c730ce",
+  "https://github.com/max-sixty/worktrunk/releases/download/v0.74.0/worktrunk-x86_64-unknown-linux-musl.tar.xz": "28392033912ab0a9027192d9975284787b29f080b4f2fd6298c89fffecf34c1f",
+  "https://github.com/max-sixty/worktrunk/releases/download/v0.74.0/worktrunk-x86_64-pc-windows-msvc.zip": "d6c588162bd2037cd7d5c66fa22c0d505f7b4be727975723e7b807f3cf99d2cf",
+}


### PR DESCRIPTION
Adds [Worktrunk](https://github.com/max-sixty/worktrunk) - a CLI for Git worktree management designed for parallel AI agent workflows.

## Test plan
- [x] Generated digests: `hermit manifest add-digests worktrunk.hcl`
- [x] Validated all manifests: `~/bin/hermit validate "file://$PWD"`
- [x] Tested installation: `hermit install worktrunk-0.74.0`
- [x] Verified binary works: `wt --version` returns `wt v0.74.0`
- [x] Verified alias works: `git-wt --version` returns `wt v0.74.0`
- [x] Uninstalled test package: `hermit uninstall worktrunk-0.74.0`

🤖 Generated with OpenAI Codex